### PR TITLE
Introducing LazyLogger, cleaning up excessive null safety handling

### DIFF
--- a/src/main/kotlin/BdvNotifier.kt
+++ b/src/main/kotlin/BdvNotifier.kt
@@ -2,6 +2,7 @@ package org.mastodon.mamut
 
 import bdv.viewer.TimePointListener
 import bdv.viewer.TransformListener
+import graphics.scenery.utils.lazyLogger
 import net.imglib2.realtransform.AffineTransform3D
 import org.mastodon.graph.GraphChangeListener
 import org.mastodon.mamut.model.Spot
@@ -31,6 +32,7 @@ class BdvNotifier(
     mastodon: ProjectModel,
     bdvWindow: MamutViewBdv
 ) {
+    private val logger by lazyLogger()
 
     init {
         //create a listener for it (which will _immediately_ collect updates from BDV)
@@ -54,7 +56,7 @@ class BdvNotifier(
         mastodon.model.graph.addGraphChangeListener(bdvUpdateListener)
         cumulatingEventsHandlerThread.start()
         bdvWindow.onClose {
-            println("Cleaning up while BDV window is closing.")
+            logger.debug("Cleaning up while BDV window is closing.")
             bdvWindow.viewerPanelMamut.renderTransformListeners().remove(bdvUpdateListener)
             bdvWindow.viewerPanelMamut.timePointListeners().remove(bdvUpdateListener)
             bdvWindow.viewerPanelMamut.removePropertyChangeListener(bdvUpdateListener)
@@ -134,17 +136,17 @@ class BdvNotifier(
         }
 
         override fun run() {
-            println("$SERVICE_NAME started")
+            logger.debug("$SERVICE_NAME started")
             try {
                 while (keepWatching) {
                     if (eventsSource.isLastContentEventValid || eventsSource.isLastViewEventValid && System.currentTimeMillis() - eventsSource.timeStampOfLastEvent > updateInterval) {
                         if (eventsSource.isLastContentEventValid) {
-                            //System.out.println(SERVICE_NAME+": content event and silence detected -> processing it now");
+                            logger.debug("$SERVICE_NAME: content event and silence detected -> processing it now");
                             eventsSource.isLastContentEventValid = false
                             contentEventProcessor.run()
                         }
                         if (eventsSource.isLastViewEventValid) {
-                            //System.out.println(SERVICE_NAME+": view event and silence detected -> processing it now");
+                            logger.debug("$SERVICE_NAME: view event and silence detected -> processing it now");
                             eventsSource.isLastViewEventValid = false
                             viewEventProcessor.run()
                         }
@@ -152,7 +154,7 @@ class BdvNotifier(
                 }
             } catch (e: InterruptedException) { /* do nothing, silently stop */
             }
-            println(SERVICE_NAME + " stopped")
+            logger.debug("$SERVICE_NAME stopped")
         }
     }
 }

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -167,7 +167,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         c.gridy++
         INTENSITY_OF_COLORS_BOOST = JCheckBox("Enable enhancing of spot colors when repainting them into the Volume")
         insertCheckBox(INTENSITY_OF_COLORS_BOOST, c)
-        c.gridy++
+//        c.gridy++
 //        UPDATE_VOLUME_VERBOSE_REPORTS = JCheckBox("Verbose/debug reporting during Volume repainting")
 //        insertCheckBox(UPDATE_VOLUME_VERBOSE_REPORTS, c)
 

--- a/src/main/kotlin/plugins/scijava/MastodonSidePlugin.kt
+++ b/src/main/kotlin/plugins/scijava/MastodonSidePlugin.kt
@@ -60,9 +60,6 @@ class MastodonSidePlugin : DynamicCommand() {
         private val logger by lazyLogger()
 
         @Parameter
-        private var logService: LogService? = null
-
-        @Parameter
         private lateinit var sciViewService: SciViewService
 
         @Parameter
@@ -80,6 +77,7 @@ class MastodonSidePlugin : DynamicCommand() {
         @Parameter(label = "Choose resolution level:", choices = [], initializer = "levelParams")
         var useThisResolutionDownscale = "[1,1,1]"
         lateinit var levelNames: MutableList<String>
+
         fun levelParams() {
             val chSource = mastodon.sharedBdvData.sources[channelIdx].spimSource
             val levels = chSource.numMipmapLevels
@@ -92,8 +90,7 @@ class MastodonSidePlugin : DynamicCommand() {
                 chSource.getSource(0, level).dimensions(curLevelDims)
                 levelNames.add("[" + baseLevelDims[0] / curLevelDims[0] + "," + baseLevelDims[1] / curLevelDims[1] + "," + baseLevelDims[2] / curLevelDims[2] + "]")
             }
-            getInfo()
-                .getMutableInput("useThisResolutionDownscale", String::class.java).choices = levelNames
+            info.getMutableInput("useThisResolutionDownscale", String::class.java).choices = levelNames
         }
 
         override fun run() {

--- a/src/main/kotlin/util/SphereNodes.kt
+++ b/src/main/kotlin/util/SphereNodes.kt
@@ -3,6 +3,7 @@ package util
 import graphics.scenery.Node
 import graphics.scenery.Sphere
 import graphics.scenery.utils.extensions.times
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import org.mastodon.mamut.ProjectModel
 import org.mastodon.mamut.model.Link
@@ -15,11 +16,12 @@ import kotlin.math.sqrt
 class SphereNodes //FAILED to hook up here a 'parentNode' listener that would setVisible(false) on all children
 //of the parent node that are "not used"
     (val sv: SciView, val parentNode: Node) {
-    var SCALE_FACTOR = 1f
-    var DEFAULT_COLOR = 0x00FFFFFF
-    val knownNodes: MutableList<Sphere> = ArrayList(1000)
-    val addedExtraNodes: MutableList<Sphere> = LinkedList()
-    private var spotRef: Spot? = null
+        private val logger by lazyLogger()
+        var SCALE_FACTOR = 1f
+        var DEFAULT_COLOR = 0x00FFFFFF
+        val knownNodes: MutableList<Sphere> = ArrayList(1000)
+        val addedExtraNodes: MutableList<Sphere> = LinkedList()
+        private var spotRef: Spot? = null
     fun showTheseSpots(
         mastodonData: ProjectModel,
         timepoint: Int,
@@ -58,9 +60,9 @@ class SphereNodes //FAILED to hook up here a 'parentNode' listener that would se
             //NB: also means that the knownNodes were fully exhausted
             knownNodes.addAll(addedExtraNodes)
             sv.publishNode(addedExtraNodes[0]) //NB: publishes only once
-            println("Added new "+addedExtraNodes.size+" spheres");
+            logger.info("Added ${addedExtraNodes.size} new spheres");
         } else {
-            println("Hide "+(knownNodes.size-visibleNodeCount)+" spheres");
+            logger.debug("Hide ${(knownNodes.size-visibleNodeCount)} spheres");
             //NB: mark not-touched knownNodes as hidden
             var i = visibleNodeCount
             while (i < knownNodes.size) {
@@ -69,7 +71,7 @@ class SphereNodes //FAILED to hook up here a 'parentNode' listener that would se
             }
         }
 /*
-		println("Drawing currently in total "+visibleNodeCount
+		logger.debug("Drawing currently in total "+visibleNodeCount
 				+ " and there are "+(knownNodes.size-visibleNodeCount)
 				+ " hidden...");
 */
@@ -115,7 +117,7 @@ class SphereNodes //FAILED to hook up here a 'parentNode' listener that would se
         if (SCALE_FACTOR < 0.4f) SCALE_FACTOR = 0.5f
         val factor = SCALE_FACTOR / oldScale
         knownNodes.forEach { s: Sphere -> s.spatial().scale *= Vector3f(factor)  }
-        println("Decreasing scale to $SCALE_FACTOR, by factor $factor")
+        logger.debug("Decreasing scale to $SCALE_FACTOR, by factor $factor")
     }
 
     fun increaseSphereScale() {
@@ -123,7 +125,7 @@ class SphereNodes //FAILED to hook up here a 'parentNode' listener that would se
         SCALE_FACTOR += 0.5f
         val factor = SCALE_FACTOR / oldScale
         knownNodes.forEach { s: Sphere -> s.spatial().scale *= Vector3f(factor) }
-        println("Increasing scale to $SCALE_FACTOR, by factor $factor")
+        logger.debug("Increasing scale to $SCALE_FACTOR, by factor $factor")
     }
 
     companion object {

--- a/src/test/kotlin/org/mastodon/mamut/StartMastodon.kt
+++ b/src/test/kotlin/org/mastodon/mamut/StartMastodon.kt
@@ -1,10 +1,12 @@
 package org.mastodon.mamut
 
 import graphics.scenery.SceneryBase
+import graphics.scenery.utils.lazyLogger
 import net.imagej.ImageJ
 import org.mastodon.mamut.launcher.MastodonLauncher
 
 object StartMastodon {
+    private val logger by lazyLogger()
     @JvmStatic
     fun main(args: Array<String>) {
         try {
@@ -24,7 +26,7 @@ object StartMastodon {
             launcher.setLocationRelativeTo(null)
             launcher.isVisible = true
         } catch (e: Exception) {
-            println("Got this exception: " + e.message)
+            logger.error("Got this exception: ${e.message}")
         }
     }
 }

--- a/src/test/kotlin/org/mastodon/mamut/StartSciviewBridgeDirectly.kt
+++ b/src/test/kotlin/org/mastodon/mamut/StartSciviewBridgeDirectly.kt
@@ -1,5 +1,6 @@
 package org.mastodon.mamut
 
+import graphics.scenery.utils.lazyLogger
 import mpicbg.spim.data.SpimDataException
 import org.mastodon.mamut.io.ProjectLoader
 import org.scijava.Context
@@ -9,6 +10,7 @@ import java.io.IOException
 import javax.swing.WindowConstants
 
 object StartSciviewBridgeDirectly {
+    private val logger by lazyLogger()
 
     @Throws(IOException::class, SpimDataException::class)
     fun giveMeMastodonOfThisProject(scijavaCtx: Context?, projectPath: String?): ProjectModel {
@@ -44,7 +46,7 @@ object StartSciviewBridgeDirectly {
             val bridge = SciviewBridge(mastodon, 0, 2, sv)
             //bridge.openSyncedBDV();
             mastodon.projectClosedListeners().add(CloseListener {
-                println("Mastodon project was closed, cleaning up in sciview:")
+                logger.debug("Mastodon project was closed, cleaning up in sciview:")
                 bridge.close() //calls also bridge.detachControllingUI();
             })
         } catch (e: Exception) {


### PR DESCRIPTION
Instead of `println()`, the project now uses lazylogger syntax everywhere. Some outputs where changed to `debug` to not clutter the console. `UPDATE_VOLUME_VERBOSE_REPORTS` was also removed, since it is now handled by the debug log level. Output strings were also changed from concatenation to string templates.

Unnecessary null safety handling was cleaned up, including a whole lot of double bangs that could've resulted in null pointer exceptions. A few other uppercase variables were renamed in the process to make them more readable.