### PR TITLE
Add basic link rendering support

### DIFF
--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -170,8 +170,9 @@ class SciviewBridge {
         logger.info("volume size is ${volumeNode.boundingBox!!.max - volumeNode.boundingBox!!.min}")
         //add the sciview-side displaying handler for the spots
         sphereLinkNodes = SphereLinkNodes(sciviewWin, mastodon, sphereParent, linkParent)
-        sphereLinkNodes.showInstancedSpots(0, noTSColorizer, true)
-        sphereLinkNodes.initializeInstancedLinks(noTSColorizer)
+        sphereLinkNodes.updateColorizer(noTSColorizer)
+        sphereLinkNodes.showInstancedSpots(0, true)
+        sphereLinkNodes.initializeInstancedLinks()
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
     }
@@ -367,8 +368,9 @@ class SciviewBridge {
     /** Calls [updateVolume] and [SphereLinkNodes.showTheseSpots] to update the current volume and corresponding spots. */
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateVolume(forThisBdv)
-        sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint, forThisBdv.colorizer)
-        sphereLinkNodes.updateInstancedLinkColors(forThisBdv.colorizer)
+        sphereLinkNodes.updateColorizer(forThisBdv.colorizer)
+        sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint)
+        sphereLinkNodes.updateInstancedLinkColors()
     }
 
     private var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -170,9 +170,8 @@ class SciviewBridge {
         logger.info("volume size is ${volumeNode.boundingBox!!.max - volumeNode.boundingBox!!.min}")
         //add the sciview-side displaying handler for the spots
         sphereLinkNodes = SphereLinkNodes(sciviewWin, mastodon, sphereParent, linkParent)
-        sphereLinkNodes.updateColorizer(noTSColorizer)
-        sphereLinkNodes.showInstancedSpots(0, true)
-        sphereLinkNodes.initializeInstancedLinks()
+        sphereLinkNodes.showInstancedSpots(0, noTSColorizer)
+        sphereLinkNodes.initializeInstancedLinks(colorizer = noTSColorizer)
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
     }
@@ -368,9 +367,8 @@ class SciviewBridge {
     /** Calls [updateVolume] and [SphereLinkNodes.showTheseSpots] to update the current volume and corresponding spots. */
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateVolume(forThisBdv)
-        sphereLinkNodes.updateColorizer(forThisBdv.colorizer)
-        sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint)
-        sphereLinkNodes.updateInstancedLinkColors()
+        sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint, forThisBdv.colorizer)
+        sphereLinkNodes.updateInstancedLinkColors(forThisBdv.colorizer)
     }
 
     private var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -73,6 +73,7 @@ class SciviewBridge {
     //sink scene graph structuring nodes
     val axesParent: Node?
     val sphereParent: Group
+    val linkParent: Group
     var volumeNode: Volume
     var spimSource: Source<out Any>
     // the source and converter that contains our volume data
@@ -155,15 +156,22 @@ class SciviewBridge {
 
         // add spots inside a sphereParent group, which makes it easier for them to inherit transforms and be manually pushed around
         sphereParent = Group()
-        sphereParent.name = "InstanceParent"
+        sphereParent.name = "SphereInstanceParent"
         sphereParent.spatial().scale /= volumeDownscale
         sciviewWin.addNode(sphereParent)
         sphereParent.parent = volumeNode
 
+        linkParent = Group()
+        linkParent.name = "LinkInstanceParent"
+        linkParent.spatial().scale /= volumeDownscale
+        sciviewWin.addNode(linkParent)
+        linkParent.parent = volumeNode
+
         logger.info("volume size is ${volumeNode.boundingBox!!.max - volumeNode.boundingBox!!.min}")
         //add the sciview-side displaying handler for the spots
-        sphereLinkNodes = SphereLinkNodes(sciviewWin, sphereParent)
+        sphereLinkNodes = SphereLinkNodes(sciviewWin, sphereParent, linkParent)
         sphereLinkNodes.showInstancedSpots(mastodon, 0, noTSColorizer, true)
+        sphereLinkNodes.initializeInstancedLinks(mastodon)
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
     }

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -169,9 +169,9 @@ class SciviewBridge {
 
         logger.info("volume size is ${volumeNode.boundingBox!!.max - volumeNode.boundingBox!!.min}")
         //add the sciview-side displaying handler for the spots
-        sphereLinkNodes = SphereLinkNodes(sciviewWin, sphereParent, linkParent)
-        sphereLinkNodes.showInstancedSpots(mastodon, 0, noTSColorizer, true)
-        sphereLinkNodes.initializeInstancedLinks(mastodon)
+        sphereLinkNodes = SphereLinkNodes(sciviewWin, mastodon, sphereParent, linkParent)
+        sphereLinkNodes.showInstancedSpots(0, noTSColorizer, true)
+        sphereLinkNodes.initializeInstancedLinks()
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
     }
@@ -367,11 +367,7 @@ class SciviewBridge {
     /** Calls [updateVolume] and [SphereLinkNodes.showTheseSpots] to update the current volume and corresponding spots. */
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateVolume(forThisBdv)
-//        sphereLinkNodes.showTheseSpots(
-//            mastodon,
-//            forThisBdv.timepoint, forThisBdv.colorizer
-//        )
-        sphereLinkNodes.showInstancedSpots(mastodon, forThisBdv.timepoint, forThisBdv.colorizer)
+        sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint, forThisBdv.colorizer)
     }
 
     private var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -137,8 +137,8 @@ class SciviewBridge {
         //
         val volumeScale = Vector3f(
             voxelRes[0] * volumeDownscale[0],
-            voxelRes[1] * volumeDownscale[1],
-            voxelRes[2] * volumeDownscale[2] * -1.0f
+            voxelRes[1] * volumeDownscale[1] * -1f,
+            voxelRes[2] * volumeDownscale[2]
         )
         var spotsScale = Vector3f(
             volumeDims[0] * voxelRes[0],
@@ -154,7 +154,7 @@ class SciviewBridge {
         setVolumeRanges(
             volChannelNode,
             "Grays.lut",
-            Vector3f(sceneScale),
+            volumeScale * Vector3f(sceneScale),
             intensity.rangeMin,
             intensity.rangeMax
         )
@@ -181,8 +181,8 @@ class SciviewBridge {
             volumeNumPixels[1].toFloat(),
             volumeNumPixels[2].toFloat()
         )
-//            .mul(0.5f, 0.5f, 0.5f) //NB: y,z axes are flipped, see SphereNodes::setSphereNode()
-//            .mul(mastodonToImgCoordsTransfer) //raw img coords to Mastodon internal coords
+            .mul(0.5f, 0.5f, 0.5f) //NB: y,z axes are flipped, see SphereNodes::setSphereNode()
+            .mul(mastodonToImgCoordsTransfer) //raw img coords to Mastodon internal coords
             .mul(spotsScale) //apply the same scaling as if "going through the SphereNodes"
         logger.info("position of sphereParent is now ${sphereParent.spatial().position}")
         logger.info("volume size is ${volChannelNode.boundingBox!!.max - volChannelNode.boundingBox!!.min}")

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -28,6 +28,7 @@ import org.scijava.event.EventService
 import org.scijava.ui.behaviour.ClickBehaviour
 import sc.iview.SciView
 import util.SphereLinkNodes
+import java.util.Vector
 import javax.swing.JFrame
 import kotlin.math.log
 import kotlin.math.max
@@ -132,14 +133,14 @@ class SciviewBridge {
         logger.info("downscale factors: ${volumeDownscale[0]} x, ${volumeDownscale[1]} x, ${volumeDownscale[2]} x")
         //
         val voxelRes = getDisplayVoxelRatio(spimSource)
-        logger.info("pixel ratios: ${voxelRes[0]} x, ${voxelRes[1]} x, ${voxelRes[2]} x")
+        logger.info("voxel res is: ${voxelRes[0]} x, ${voxelRes[1]} x, ${voxelRes[2]} x")
         //
         val volumeScale = Vector3f(
             voxelRes[0] * volumeDownscale[0],
             voxelRes[1] * volumeDownscale[1],
             voxelRes[2] * volumeDownscale[2] * -1.0f
         )
-        val spotsScale = Vector3f(
+        var spotsScale = Vector3f(
             volumeDims[0] * voxelRes[0],
             volumeDims[1] * voxelRes[1],
             volumeDims[2] * voxelRes[2]
@@ -153,7 +154,7 @@ class SciviewBridge {
         setVolumeRanges(
             volChannelNode,
             "Grays.lut",
-            volumeScale * sceneScale,
+            Vector3f(sceneScale),
             intensity.rangeMin,
             intensity.rangeMax
         )
@@ -172,6 +173,7 @@ class SciviewBridge {
             voxelRes[2] * volumeDownscale[2]
         )
         logger.info("mastodonToImgCoordsTransfer is $mastodonToImgCoordsTransfer")
+        spotsScale = Vector3f(0.01f)
         sphereParent.spatial().scale = spotsScale
         // initialize the base position
         sphereParent.spatial().position = Vector3f(
@@ -179,10 +181,9 @@ class SciviewBridge {
             volumeNumPixels[1].toFloat(),
             volumeNumPixels[2].toFloat()
         )
-            .mul(0.5f, 0.5f, 0.5f) //NB: y,z axes are flipped, see SphereNodes::setSphereNode()
-            .mul(mastodonToImgCoordsTransfer) //raw img coords to Mastodon internal coords
+//            .mul(0.5f, 0.5f, 0.5f) //NB: y,z axes are flipped, see SphereNodes::setSphereNode()
+//            .mul(mastodonToImgCoordsTransfer) //raw img coords to Mastodon internal coords
             .mul(spotsScale) //apply the same scaling as if "going through the SphereNodes"
-        sphereParent.spatial().position = Vector3f(0f)
         logger.info("position of sphereParent is now ${sphereParent.spatial().position}")
         logger.info("volume size is ${volChannelNode.boundingBox!!.max - volChannelNode.boundingBox!!.min}")
         //add the sciview-side displaying handler for the spots
@@ -407,6 +408,7 @@ class SciviewBridge {
 //            forThisBdv.timepoint, forThisBdv.colorizer
 //        )
 //        sphereLinkNodes.initializeSpots(mastodon, forThisBdv.timepoint, forThisBdv.colorizer)
+        sphereLinkNodes.setInstancedSphereColors(forThisBdv.colorizer)
     }
 
     private var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -28,7 +28,7 @@ import org.mastodon.ui.coloring.TagSetGraphColorGenerator
 import org.scijava.event.EventService
 import org.scijava.ui.behaviour.ClickBehaviour
 import sc.iview.SciView
-import util.SphereNodes
+import util.SphereLinkNodes
 import javax.swing.JFrame
 import kotlin.math.max
 import kotlin.math.min
@@ -78,7 +78,7 @@ class SciviewBridge {
 
     //data sink stuff
     val sciviewWin: SciView
-    val sphereNodes: SphereNodes
+    val sphereLinkNodes: SphereLinkNodes
     //sink scene graph structuring nodes
     val axesParent: Node?
     val sphereParent: Group
@@ -248,8 +248,8 @@ class SciviewBridge {
             .mul(spotsScale) //apply the same scaling as if "going through the SphereNodes"
 
         //add the sciview-side displaying handler for the spots
-        sphereNodes = SphereNodes(sciviewWin, sphereParent)
-        sphereNodes.showTheseSpots(mastodon, 0, noTSColorizer)
+        sphereLinkNodes = SphereLinkNodes(sciviewWin, sphereParent)
+        sphereLinkNodes.showTheseSpots(mastodon, 0, noTSColorizer)
 
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
@@ -549,7 +549,7 @@ class SciviewBridge {
     //------------------------------
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateSVColoring(forThisBdv)
-        sphereNodes.showTheseSpots(
+        sphereLinkNodes.showTheseSpots(
             mastodon,
             forThisBdv.timepoint, forThisBdv.colorizer
         )
@@ -655,7 +655,7 @@ class SciviewBridge {
         sphereParent.visible = state
         if (state) {
             sphereParent
-                .getChildrenByName(SphereNodes.NAME_OF_NOT_USED_SPHERES)
+                .getChildrenByName(SphereLinkNodes.NAME_OF_NOT_USED_SPHERES)
                 .forEach { s: Node -> s.visible = false }
         }
     }
@@ -680,13 +680,13 @@ class SciviewBridge {
         val handler = sciviewWin.sceneryInputHandler
         handler?.addKeyBinding(desc_DEC_SPH, key_DEC_SPH)
         handler?.addBehaviour(desc_DEC_SPH, ClickBehaviour { _, _ ->
-            sphereNodes.decreaseSphereScale()
+            sphereLinkNodes.decreaseSphereScale()
             updateUI()
         })
         //
         handler?.addKeyBinding(desc_INC_SPH, key_INC_SPH)
         handler?.addBehaviour(desc_INC_SPH, ClickBehaviour { _, _ ->
-            sphereNodes.increaseSphereScale()
+            sphereLinkNodes.increaseSphereScale()
             updateUI()
         })
         //

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -171,7 +171,7 @@ class SciviewBridge {
         //add the sciview-side displaying handler for the spots
         sphereLinkNodes = SphereLinkNodes(sciviewWin, mastodon, sphereParent, linkParent)
         sphereLinkNodes.showInstancedSpots(0, noTSColorizer)
-        sphereLinkNodes.initializeInstancedLinks(colorizer = noTSColorizer)
+        sphereLinkNodes.initializeInstancedLinks(SphereLinkNodes.colorMode.LUT, colorizer = noTSColorizer)
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
     }
@@ -202,7 +202,7 @@ class SciviewBridge {
         sciviewWin.deleteNode(axesParent, true)
     }
 
-    /** Adds a volume to the sciview scene, adjusts the transfer function to a ramp from [0, 0] to [1, 1]
+    /** Adds a volume to the sciview scene, scales it by [scale], adjusts the transfer function to a ramp from [0, 0] to [1, 1]
      * and sets the node children visibility to false. */
     private fun setVolumeRanges(
         v: Volume?,
@@ -213,7 +213,6 @@ class SciviewBridge {
     ) {
         v?.let {
             sciviewWin.setColormap(it, colorMapName)
-//            it.spatial().scale = scale
             it.spatial().scale = scale
             it.minDisplayRange = displayRangeMin
             it.maxDisplayRange = displayRangeMax
@@ -368,7 +367,7 @@ class SciviewBridge {
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateVolume(forThisBdv)
         sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint, forThisBdv.colorizer)
-        sphereLinkNodes.updateInstancedLinkColors(forThisBdv.colorizer)
+        sphereLinkNodes.updateLinkColors(forThisBdv.colorizer, SphereLinkNodes.colorMode.LUT)
     }
 
     private var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -90,7 +90,8 @@ class SciviewBridge {
 
     constructor(
         mastodonMainWindow: ProjectModel,
-        sourceID: Int, sourceResLevel: Int,
+        sourceID: Int,
+        sourceResLevel: Int,
         targetSciviewWindow: SciView
     ) {
         mastodon = mastodonMainWindow
@@ -171,7 +172,7 @@ class SciviewBridge {
         //add the sciview-side displaying handler for the spots
         sphereLinkNodes = SphereLinkNodes(sciviewWin, mastodon, sphereParent, linkParent)
         sphereLinkNodes.showInstancedSpots(0, noTSColorizer)
-        sphereLinkNodes.initializeInstancedLinks(SphereLinkNodes.colorMode.LUT, colorizer = noTSColorizer)
+        sphereLinkNodes.initializeInstancedLinks(SphereLinkNodes.ColorMode.LUT, colorizer = noTSColorizer)
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
     }
@@ -362,14 +363,15 @@ class SciviewBridge {
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateVolume(forThisBdv)
         sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint, forThisBdv.colorizer)
+        sphereLinkNodes.updateLinkVisibility(forThisBdv.timepoint)
 //        sphereLinkNodes.updateLinkColors(forThisBdv.colorizer)
     }
 
-    private var lastTpWhenVolumeWasUpdated = 0
+    var lastTpWhenVolumeWasUpdated = 0
     val detachedDPP_showsLastTimepoint: DisplayParamsProvider = DPP_Detached()
 
     /** Fetch the volume state at the current time point,
-     * then call [volumeIntensityProcessing] to adjust the intensity values*/
+     * then call [volumeIntensityProcessing] to adjust the intensity values */
     @JvmOverloads
     fun updateVolume(
         forThisBdv: DisplayParamsProvider = detachedDPP_showsLastTimepoint,

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -251,6 +251,7 @@ class SciviewBridge {
         sphereLinkNodes = SphereLinkNodes(sciviewWin, sphereParent)
         sphereLinkNodes.showTheseSpots(mastodon, 0, noTSColorizer)
 
+
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
     }

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -364,7 +364,7 @@ class SciviewBridge {
         updateVolume(forThisBdv)
         sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint, forThisBdv.colorizer)
         sphereLinkNodes.updateLinkVisibility(forThisBdv.timepoint)
-//        sphereLinkNodes.updateLinkColors(forThisBdv.colorizer)
+        sphereLinkNodes.updateLinkColors(forThisBdv.colorizer)
     }
 
     var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -155,13 +155,14 @@ class SciviewBridge {
 
         // add spots inside a sphereParent group, which makes it easier for them to inherit transforms and be manually pushed around
         sphereParent = Group()
+        sphereParent.name = "InstanceParent"
         sphereParent.spatial().scale /= volumeDownscale
-        volumeNode.addChild(sphereParent)
+        sciviewWin.addNode(sphereParent)
+        sphereParent.parent = volumeNode
 
         logger.info("volume size is ${volumeNode.boundingBox!!.max - volumeNode.boundingBox!!.min}")
         //add the sciview-side displaying handler for the spots
         sphereLinkNodes = SphereLinkNodes(sciviewWin, sphereParent)
-//        sphereLinkNodes.showTheseSpots(mastodon, 0, noTSColorizer)
         sphereLinkNodes.showInstancedSpots(mastodon, 0, noTSColorizer, true)
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -205,7 +205,7 @@ class SciviewBridge {
         //add the sciview-side displaying handler for the spots
         sphereLinkNodes = SphereLinkNodes(sciviewWin, sphereParent)
 //        sphereLinkNodes.showTheseSpots(mastodon, 0, noTSColorizer)
-        sphereLinkNodes.initializeInstancedSpots(mastodon, 0, noTSColorizer)
+        sphereLinkNodes.showInstancedSpots(mastodon, 0, noTSColorizer, true)
 //        sphereParent.postUpdate.add {sphereLinkNodes.updateInstancedSpots(mastodon, 0, noTSColorizer)}
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
@@ -425,7 +425,7 @@ class SciviewBridge {
 //            mastodon,
 //            forThisBdv.timepoint, forThisBdv.colorizer
 //        )
-        sphereLinkNodes.updateInstancedSpots(mastodon, forThisBdv.timepoint, forThisBdv.colorizer)
+        sphereLinkNodes.showInstancedSpots(mastodon, forThisBdv.timepoint, forThisBdv.colorizer)
     }
 
     private var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -302,7 +302,7 @@ class SciviewBridge {
     }
 
     private var recentTagSet: TagSetStructure.TagSet? = null
-    private var recentColorizer: GraphColorGenerator<Spot, Link>? = null
+    var recentColorizer: GraphColorGenerator<Spot, Link>? = null
     private val noTSColorizer = DefaultGraphColorGenerator<Spot, Link>()
     private fun getCurrentColorizer(forThisBdv: MamutViewBdv): GraphColorGenerator<Spot, Link> {
         //NB: trying to avoid re-creating of new TagSetGraphColorGenerator objs with every new content rending

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -171,7 +171,7 @@ class SciviewBridge {
         //add the sciview-side displaying handler for the spots
         sphereLinkNodes = SphereLinkNodes(sciviewWin, mastodon, sphereParent, linkParent)
         sphereLinkNodes.showInstancedSpots(0, noTSColorizer, true)
-        sphereLinkNodes.initializeInstancedLinks()
+        sphereLinkNodes.initializeInstancedLinks(noTSColorizer)
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
     }
@@ -368,6 +368,7 @@ class SciviewBridge {
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateVolume(forThisBdv)
         sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint, forThisBdv.colorizer)
+        sphereLinkNodes.updateInstancedLinkColors(forThisBdv.colorizer)
     }
 
     private var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -420,6 +420,7 @@ class SciviewBridge {
     }
 
     val detachedDPP_withOwnTime: DPP_DetachedOwnTime
+
     fun showTimepoint(timepoint: Int) {
         detachedDPP_withOwnTime.timepoint = timepoint
         updateSciviewContent(detachedDPP_withOwnTime)
@@ -427,48 +428,27 @@ class SciviewBridge {
 
     private fun registerKeyboardHandlers() {
 
-        val handler = sciviewWin.sceneryInputHandler
-        handler?.addKeyBinding(desc_DEC_SPH, key_DEC_SPH)
-        handler?.addBehaviour(desc_DEC_SPH, ClickBehaviour { _, _ ->
-            sphereLinkNodes.decreaseSphereScale()
-            updateUI()
-        })
+        data class BehaviourTriple(val name: String, val key: String, val lambda: ClickBehaviour)
 
-        handler?.addKeyBinding(desc_INC_SPH, key_INC_SPH)
-        handler?.addBehaviour(desc_INC_SPH, ClickBehaviour { _, _ ->
-            sphereLinkNodes.increaseSphereScale()
-            updateUI()
-        })
+        val handler = sciviewWin.sceneryInputHandler ?: throw IllegalStateException("Could not find input handler!")
 
-        handler?.addKeyBinding(desc_DEC_LINK, key_DEC_LINK)
-        handler?.addBehaviour(desc_DEC_LINK, ClickBehaviour { _, _ ->
-            sphereLinkNodes.decreaseLinkScale()
-            updateUI()
-        })
+        val behaviourCollection = arrayOf(
+            BehaviourTriple(desc_DEC_SPH, key_DEC_SPH, { _, _ -> sphereLinkNodes.decreaseSphereScale(); updateUI() }),
+            BehaviourTriple(desc_INC_SPH, key_INC_SPH, { _, _ -> sphereLinkNodes.increaseSphereScale(); updateUI() }),
+            BehaviourTriple(desc_DEC_LINK, key_DEC_LINK, { _, _ -> sphereLinkNodes.decreaseLinkScale(); updateUI() }),
+            BehaviourTriple(desc_INC_LINK, key_INC_LINK, { _, _ -> sphereLinkNodes.increaseLinkScale(); updateUI() }),
+            BehaviourTriple(desc_CTRL_WIN, key_CTRL_WIN, { _, _ -> createAndShowControllingUI() }),
+            BehaviourTriple(desc_CTRL_INFO, key_CTRL_INFO, { _, _ -> logger.info(this.toString()) }),
+            BehaviourTriple(desc_PREV_TP, key_PREV_TP, { _, _ -> detachedDPP_withOwnTime.prevTimepoint()
+                updateSciviewContent(detachedDPP_withOwnTime) }),
+            BehaviourTriple(desc_NEXT_TP, key_NEXT_TP, { _, _ -> detachedDPP_withOwnTime.nextTimepoint()
+                updateSciviewContent(detachedDPP_withOwnTime) })
+        )
 
-        handler?.addKeyBinding(desc_INC_LINK, key_INC_LINK)
-        handler?.addBehaviour(desc_INC_LINK, ClickBehaviour { _, _ ->
-            sphereLinkNodes.increaseLinkScale()
-            updateUI()
-        })
-
-        handler?.addKeyBinding(desc_CTRL_WIN, key_CTRL_WIN)
-        handler?.addBehaviour(desc_CTRL_WIN, ClickBehaviour { _, _ -> createAndShowControllingUI() })
-
-        handler?.addKeyBinding(desc_CTRL_INFO, key_CTRL_INFO)
-        handler?.addBehaviour(desc_CTRL_INFO, ClickBehaviour { _, _ -> logger.info(this.toString()) })
-
-        handler?.addKeyBinding(desc_PREV_TP, key_PREV_TP)
-        handler?.addBehaviour(desc_PREV_TP, ClickBehaviour { _, _ ->
-            detachedDPP_withOwnTime.prevTimepoint()
-            updateSciviewContent(detachedDPP_withOwnTime)
-        })
-
-        handler?.addKeyBinding(desc_NEXT_TP, key_NEXT_TP)
-        handler?.addBehaviour(desc_NEXT_TP, ClickBehaviour { _, _ ->
-            detachedDPP_withOwnTime.nextTimepoint()
-            updateSciviewContent(detachedDPP_withOwnTime)
-        })
+        behaviourCollection.forEach {
+            handler.addKeyBinding(it.name, it.key)
+            handler.addBehaviour(it.name, it.lambda)
+        }
     }
 
     private fun deregisterKeyboardHandlers() {

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -8,10 +8,14 @@ import graphics.scenery.utils.extensions.times
 import graphics.scenery.utils.lazyLogger
 import graphics.scenery.volumes.TransferFunction
 import graphics.scenery.volumes.Volume
+import net.imagej.Data
+import net.imagej.Dataset
 import net.imglib2.RandomAccessibleInterval
+import net.imglib2.img.Img
 import net.imglib2.loops.LoopBuilder
 import net.imglib2.realtransform.AffineTransform3D
 import net.imglib2.type.numeric.IntegerType
+import net.imglib2.type.numeric.RealType
 import net.imglib2.type.numeric.integer.UnsignedShortType
 import net.imglib2.view.Views
 import org.joml.Matrix4f
@@ -30,10 +34,7 @@ import sc.iview.SciView
 import util.SphereLinkNodes
 import java.util.Vector
 import javax.swing.JFrame
-import kotlin.math.log
-import kotlin.math.max
-import kotlin.math.min
-import kotlin.math.pow
+import kotlin.math.*
 
 class SciviewBridge {
     private val logger by lazyLogger()
@@ -407,8 +408,8 @@ class SciviewBridge {
 //            mastodon,
 //            forThisBdv.timepoint, forThisBdv.colorizer
 //        )
-//        sphereLinkNodes.initializeSpots(mastodon, forThisBdv.timepoint, forThisBdv.colorizer)
-        sphereLinkNodes.setInstancedSphereColors(forThisBdv.colorizer)
+        sphereLinkNodes.initializeSpots(mastodon, forThisBdv.timepoint, forThisBdv.colorizer)
+//        sphereLinkNodes.setInstancedSphereColors(forThisBdv.colorizer)
     }
 
     private var lastTpWhenVolumeWasUpdated = 0
@@ -442,9 +443,15 @@ class SciviewBridge {
     }
 
     private fun updateSciviewCamera(forThisBdv: MamutViewBdv) {
+        val auxTransform = AffineTransform3D()
+        val viewMatrix = Matrix4f()
+        val viewRotation = Quaternionf()
         forThisBdv.viewerPanelMamut.state().getViewerTransform(auxTransform)
+        logger.info("bdv transform matrix: $auxTransform")
         for (r in 0..2) for (c in 0..3) viewMatrix[c, r] = auxTransform[r, c].toFloat()
+        logger.info("viewMatrix is $viewMatrix")
         viewMatrix.getUnnormalizedRotation(viewRotation)
+        logger.info("viewRotation is $viewRotation")
         val camSpatial = sciviewWin.camera?.spatial() ?: return
         viewRotation.y *= -1f
         viewRotation.z *= -1f
@@ -453,9 +460,7 @@ class SciviewBridge {
         camSpatial.position = sciviewWin.camera?.forward!!.normalize().mul(-1f * dist)
     }
 
-    private val auxTransform = AffineTransform3D()
-    private val viewMatrix = Matrix4f()
-    private val viewRotation = Quaternionf()
+
 
     // --------------------------------------------------------------------------
     fun setVisibilityOfVolume(state: Boolean) {

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -303,7 +303,7 @@ class SciviewBridge {
 
     private var recentTagSet: TagSetStructure.TagSet? = null
     var recentColorizer: GraphColorGenerator<Spot, Link>? = null
-    private val noTSColorizer = DefaultGraphColorGenerator<Spot, Link>()
+    val noTSColorizer = DefaultGraphColorGenerator<Spot, Link>()
     private fun getCurrentColorizer(forThisBdv: MamutViewBdv): GraphColorGenerator<Spot, Link> {
         //NB: trying to avoid re-creating of new TagSetGraphColorGenerator objs with every new content rending
         val colorizer: GraphColorGenerator<Spot, Link>
@@ -362,7 +362,7 @@ class SciviewBridge {
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateVolume(forThisBdv)
         sphereLinkNodes.showInstancedSpots(forThisBdv.timepoint, forThisBdv.colorizer)
-        sphereLinkNodes.updateLinkColors(forThisBdv.colorizer, SphereLinkNodes.colorMode.LUT)
+//        sphereLinkNodes.updateLinkColors(forThisBdv.colorizer)
     }
 
     private var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -185,11 +185,6 @@ class SciviewBridge {
         logger.info("Mastodon-sciview Bridge closing procedure: UI and keyboard handlers are removed now")
         sciviewWin.setActiveNode(axesParent)
         logger.info("Mastodon-sciview Bridge closing procedure: focus shifted away from our nodes")
-
-        //first make invisible, then remove...
-        setVisibilityOfVolume(false)
-        setVisibilityOfSpots(false)
-        logger.debug("Mastodon-sciview Bridge closing procedure: our nodes made hidden")
         val updateGraceTime = 100L // in ms
         try {
             sciviewWin.deleteNode(volumeNode, true)
@@ -414,15 +409,6 @@ class SciviewBridge {
             volumeNode.children.stream()
                 .filter { c: Node -> c.name.startsWith("Bounding") }
                 .forEach { c: Node -> c.visible = false }
-        }
-    }
-
-    fun setVisibilityOfSpots(state: Boolean) {
-        sphereParent.visible = state
-        if (state) {
-            sphereParent
-                .getChildrenByName(SphereLinkNodes.NAME_OF_NOT_USED_SPHERES)
-                .forEach { s: Node -> s.visible = false }
         }
     }
 

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -174,8 +174,8 @@ class SciviewBridge {
 
         //add the sciview-side displaying handler for the spots
         sphereLinkNodes = SphereLinkNodes(sciviewWin, sphereParent)
-        sphereLinkNodes.showTheseSpots(mastodon, 0, noTSColorizer)
-
+//        sphereLinkNodes.showTheseSpots(mastodon, 0, noTSColorizer)
+        sphereLinkNodes.initializeSpots(mastodon, 0, noTSColorizer)
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
     }
@@ -388,10 +388,10 @@ class SciviewBridge {
     /** Calls [updateVolume] and [SphereNodes.showTheseSpots] to update the current volume and corresponding spots. */
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateVolume(forThisBdv)
-        sphereLinkNodes.showTheseSpots(
-            mastodon,
-            forThisBdv.timepoint, forThisBdv.colorizer
-        )
+//        sphereLinkNodes.showTheseSpots(
+//            mastodon,
+//            forThisBdv.timepoint, forThisBdv.colorizer
+//        )
 //        sphereLinkNodes.initializeSpots(mastodon, forThisBdv.timepoint, forThisBdv.colorizer)
     }
 

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -458,6 +458,18 @@ class SciviewBridge {
             updateUI()
         })
 
+        handler?.addKeyBinding(desc_DEC_LINK, key_DEC_LINK)
+        handler?.addBehaviour(desc_DEC_LINK, ClickBehaviour { _, _ ->
+            sphereLinkNodes.decreaseLinkScale()
+            updateUI()
+        })
+
+        handler?.addKeyBinding(desc_INC_LINK, key_INC_LINK)
+        handler?.addBehaviour(desc_INC_LINK, ClickBehaviour { _, _ ->
+            sphereLinkNodes.increaseLinkScale()
+            updateUI()
+        })
+
         handler?.addKeyBinding(desc_CTRL_WIN, key_CTRL_WIN)
         handler?.addBehaviour(desc_CTRL_WIN, ClickBehaviour { _, _ -> createAndShowControllingUI() })
 
@@ -482,6 +494,8 @@ class SciviewBridge {
         if (handler != null) {
             listOf(desc_DEC_SPH,
                 desc_INC_SPH,
+                desc_DEC_LINK,
+                desc_INC_LINK,
                 desc_CTRL_WIN,
                 desc_CTRL_INFO,
                 desc_PREV_TP,
@@ -567,12 +581,16 @@ class SciviewBridge {
         // --------------------------------------------------------------------------
         const val key_DEC_SPH = "O"
         const val key_INC_SPH = "shift O"
+        const val key_DEC_LINK = "L"
+        const val key_INC_LINK = "shift L"
         const val key_CTRL_WIN = "ctrl I"
         const val key_CTRL_INFO = "shift I"
         const val key_PREV_TP = "T"
         const val key_NEXT_TP = "shift T"
         const val desc_DEC_SPH = "decrease_initial_spheres_size"
         const val desc_INC_SPH = "increase_initial_spheres_size"
+        const val desc_DEC_LINK = "decrease_initial_links_size"
+        const val desc_INC_LINK = "increase_initial_links_size"
         const val desc_CTRL_WIN = "controlling_window"
         const val desc_CTRL_INFO = "controlling_info"
         const val desc_PREV_TP = "show_previous_timepoint"

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -118,11 +118,12 @@ class SciviewBridge {
         spimSource = mastodon.sharedBdvData.sources[this.sourceID].spimSource
         val volumeDims = spimSource.getSource(0, 0).dimensionsAsLongArray()
         //SOURCE_USED_RES_LEVEL = spimSource.getNumMipmapLevels() > 1 ? 1 : 0;
-        val volumeDimsUsedResLevel = spimSource.getSource(0, this.sourceResLevel).dimensionsAsLongArray()
+        // absolute number of pixels for each dimension of the volume
+        val volumeNumPixels = spimSource.getSource(0, this.sourceResLevel).dimensionsAsLongArray()
         val volumeDownscale = floatArrayOf(
-            volumeDims[0].toFloat() / volumeDimsUsedResLevel[0].toFloat(),
-            volumeDims[1].toFloat() / volumeDimsUsedResLevel[1].toFloat(),
-            volumeDims[2].toFloat() / volumeDimsUsedResLevel[2].toFloat()
+            volumeDims[0].toFloat() / volumeNumPixels[0].toFloat(),
+            volumeDims[1].toFloat() / volumeNumPixels[1].toFloat(),
+            volumeDims[2].toFloat() / volumeNumPixels[2].toFloat()
         )
         logger.info("downscale factors: ${volumeDownscale[0]} x, ${volumeDownscale[1]} x, ${volumeDownscale[2]} x")
         //
@@ -163,9 +164,9 @@ class SciviewBridge {
         )
         sphereParent.spatial().scale = spotsScale
         sphereParent.spatial().position = Vector3f(
-            volumeDimsUsedResLevel[0].toFloat(),
-            volumeDimsUsedResLevel[1].toFloat(),
-            volumeDimsUsedResLevel[2].toFloat()
+            volumeNumPixels[0].toFloat(),
+            volumeNumPixels[1].toFloat(),
+            volumeNumPixels[2].toFloat()
         )
             .mul(-0.5f, 0.5f, 0.5f) //NB: y,z axes are flipped, see SphereNodes::setSphereNode()
             .mul(mastodonToImgCoordsTransfer) //raw img coords to Mastodon internal coords
@@ -174,7 +175,6 @@ class SciviewBridge {
         //add the sciview-side displaying handler for the spots
         sphereLinkNodes = SphereLinkNodes(sciviewWin, sphereParent)
         sphereLinkNodes.showTheseSpots(mastodon, 0, noTSColorizer)
-
 
         //temporary handlers, originally for testing....
         registerKeyboardHandlers()
@@ -388,12 +388,11 @@ class SciviewBridge {
     /** Calls [updateVolume] and [SphereNodes.showTheseSpots] to update the current volume and corresponding spots. */
     fun updateSciviewContent(forThisBdv: DisplayParamsProvider) {
         updateVolume(forThisBdv)
-        sphereNodes.showTheseSpots(
-        updateSVColoring(forThisBdv)
         sphereLinkNodes.showTheseSpots(
             mastodon,
             forThisBdv.timepoint, forThisBdv.colorizer
         )
+//        sphereLinkNodes.initializeSpots(mastodon, forThisBdv.timepoint, forThisBdv.colorizer)
     }
 
     private var lastTpWhenVolumeWasUpdated = 0

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -8,6 +8,7 @@ import java.awt.*
 import java.awt.event.ActionListener
 import java.util.function.Consumer
 import javax.swing.*
+import javax.swing.border.EmptyBorder
 import javax.swing.event.ChangeEvent
 import javax.swing.event.ChangeListener
 
@@ -159,8 +160,9 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
 
         // color parameters
         c.gridy++
-        c.gridwidth = 1
+        c.gridwidth = 4
         val colorPlaceholder = JPanel()
+        c.gridx = 0
         controlsWindowPanel.add(colorPlaceholder, c)
         colorPlaceholder.setLayout(GridBagLayout())
         val coloringRow = GridBagConstraints()
@@ -228,7 +230,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
 
         // -------------- button row --------------
         c.gridy++
-        c.gridx = 1
+        c.gridx = 0
         c.gridwidth = 1
         c.anchor = GridBagConstraints.EAST
 //        c.insets = Insets(0, 0, 10, 0)
@@ -236,7 +238,6 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         closeBtn.addActionListener { bridge.detachControllingUI() }
 //        insertRColumnItem(closeBtn, c)
         controlsWindowPanel.add(closeBtn, c)
-//        c.insets = Insets(10, 0, 10, 0)
     }
 
     val sideSpace = 15

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -129,13 +129,17 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
 
         // links window range
         c.gridy++
+        c.gridwidth = 2
         c.gridx = 0
         insertLabel("Link window range backwards", c)
         c.gridx = 1
         linkRangeBackwards = SpinnerNumberModel(bridge.mastodon.maxTimepoint, 0, bridge.mastodon.maxTimepoint, 1)
         insertSpinner(
             linkRangeBackwards,
-            {f: Float -> bridge.sphereLinkNodes.linkBackwardRange = f.toInt()},
+            {
+                f: Float -> bridge.sphereLinkNodes.linkBackwardRange = f.toInt()
+                bridge.sphereLinkNodes.updateLinkVisibility(bridge.lastTpWhenVolumeWasUpdated)
+            },
             c)
 
         c.gridy++
@@ -145,13 +149,17 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         linkRangeForwards = SpinnerNumberModel(bridge.mastodon.maxTimepoint, 0, bridge.mastodon.maxTimepoint, 1)
         insertSpinner(
             linkRangeForwards,
-            {f: Float -> bridge.sphereLinkNodes.linkForwardRange = f.toInt()},
+            {
+                f: Float -> bridge.sphereLinkNodes.linkForwardRange = f.toInt()
+                bridge.sphereLinkNodes.updateLinkVisibility(bridge.lastTpWhenVolumeWasUpdated)
+            },
             c
         )
 
 
         // color parameters
         c.gridy++
+        c.gridwidth = 1
         val colorPlaceholder = JPanel()
         controlsWindowPanel.add(colorPlaceholder, c)
         colorPlaceholder.setLayout(GridBagLayout())
@@ -250,8 +258,8 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         controlsWindowPanel.add(JLabel(labelText), c)
     }
 
-    val spinnerMinDim = Dimension(200, 20)
-    val spinnerMaxDim = Dimension(1000, 20)
+    val spinnerMinDim = Dimension(40, 20)
+    val spinnerMaxDim = Dimension(200, 20)
     fun insertSpinner(
         model: SpinnerModel,
         updaterOnEvents: Consumer<Float>,
@@ -322,11 +330,11 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
     val chooseLinkColormap = ActionListener { _ ->
         when (linkColorSelector.selectedItem) {
             "By Spot" -> {
-                controlledBridge.sphereLinkNodes.currentColorMode = SphereLinkNodes.colorMode.SPOT
+                controlledBridge.sphereLinkNodes.currentColorMode = SphereLinkNodes.ColorMode.SPOT
                 logger.info("Coloring links by spot color")
             }
             else -> {
-                controlledBridge.sphereLinkNodes.currentColorMode = SphereLinkNodes.colorMode.LUT
+                controlledBridge.sphereLinkNodes.currentColorMode = SphereLinkNodes.ColorMode.LUT
                 controlledBridge.sphereLinkNodes.setLUT("${linkColorSelector.selectedItem}.lut")
                 logger.info("Coloring links with LUT ${linkColorSelector.selectedItem}")
             }

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -303,7 +303,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
             else -> {
                 controlledBridge.sphereLinkNodes.currentColorMode = SphereLinkNodes.colorMode.LUT
                 controlledBridge.sphereLinkNodes.setLUT("${linkColorSelector.selectedItem}.lut")
-                logger.info("Coloring links with LUT $linkColorSelector.selectedItem")
+                logger.info("Coloring links with LUT ${linkColorSelector.selectedItem}")
             }
         }
         controlledBridge.sphereLinkNodes.updateLinkColors(controlledBridge.recentColorizer ?: controlledBridge.noTSColorizer)
@@ -311,7 +311,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
 
     val chooseVolumeColormap = ActionListener {
         controlledBridge.sciviewWin.setColormap(controlledBridge.volumeNode, "${volumeColorSelector.selectedItem}.lut")
-        logger.info("Coloring volume with LUT $volumeColorSelector.selectedItem")
+        logger.info("Coloring volume with LUT ${volumeColorSelector.selectedItem}")
     }
 
     val toggleSpotsVisibility = ActionListener {

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -228,15 +228,14 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         buttonRow.insets = Insets(0, 20, 0, 0)
         fourButtonsPlaceholder.add(visToggleTracks, buttonRow)
 
-        // -------------- button row --------------
+        // -------------- close button row --------------
         c.gridy++
-        c.gridx = 0
+        c.gridx = 1
         c.gridwidth = 1
         c.anchor = GridBagConstraints.EAST
-//        c.insets = Insets(0, 0, 10, 0)
         val closeBtn = JButton("Close")
         closeBtn.addActionListener { bridge.detachControllingUI() }
-//        insertRColumnItem(closeBtn, c)
+        c.insets = Insets(0, 0, 10, 15)
         controlsWindowPanel.add(closeBtn, c)
     }
 

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -13,6 +13,20 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
     var controlledBridge: SciviewBridge?
     val controlsWindowPanel: Container
 
+    //int SOURCE_ID = 0;
+    //int SOURCE_USED_RES_LEVEL = 0;
+    lateinit var INTENSITY_CONTRAST: SpinnerModel
+    lateinit var INTENSITY_SHIFT: SpinnerModel
+    lateinit var INTENSITY_CLAMP_AT_TOP: SpinnerModel
+    lateinit var INTENSITY_GAMMA: SpinnerModel
+    lateinit var INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM: AdjustableBoundsRangeSlider
+    //
+    lateinit var visToggleSpots: JButton
+    lateinit var visToggleVols: JButton
+    lateinit var visToggleTracks: JButton
+    lateinit var autoIntensityBtn: JToggleButton
+    lateinit var lockGroupHandler: GroupLocksHandling
+
     // -------------------------------------------------------------------------------------------
     private fun populatePane() {
         val bridge = this.controlledBridge ?: throw IllegalStateException("The passed bridge cannot be null.")
@@ -105,39 +119,46 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         )
         INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM.addChangeListener(rangeSliderListener)
         c.gridy++
-        visToggleSpots = JButton("Toggle visibility of SPOTS")
+        visToggleSpots = JButton("Toggle spots")
         visToggleSpots.addActionListener(toggleSpotsVisibility)
-        visToggleVols = JButton("Toggle visibility of VOLUME")
+        visToggleVols = JButton("Toggle volume")
         visToggleVols.addActionListener(toggleVolumeVisibility)
+        visToggleTracks = JButton("Toggle tracks")
+        visToggleTracks.addActionListener(toggleTrackVisivility)
+
         autoIntensityBtn = JToggleButton("Auto Intensity", bridge.isVolumeAutoAdjust)
         autoIntensityBtn.addActionListener(autoAdjustIntensity)
         //
-        val threeCenteredButtonsPlaceHolder = JPanel()
-        controlsWindowPanel.add(threeCenteredButtonsPlaceHolder, c)
+        val fourButtonsPlaceholder = JPanel()
+        controlsWindowPanel.add(fourButtonsPlaceholder, c)
         //
-        threeCenteredButtonsPlaceHolder.setLayout(GridBagLayout())
+        fourButtonsPlaceholder.setLayout(GridBagLayout())
         val bc = GridBagConstraints()
         bc.fill = GridBagConstraints.HORIZONTAL
         bc.weightx = 0.4
         bc.gridx = 0
 //        bc.insets = Insets(0, 20, 0, 0)
-        threeCenteredButtonsPlaceHolder.add(autoIntensityBtn, bc)
+        fourButtonsPlaceholder.add(autoIntensityBtn, bc)
         bc.gridx = 1
         bc.insets = Insets(0, 20, 0, 0)
-        threeCenteredButtonsPlaceHolder.add(visToggleSpots, bc)
+        fourButtonsPlaceholder.add(visToggleSpots, bc)
         bc.gridx = 2
         bc.insets = Insets(0, 20, 0, 0)
-        threeCenteredButtonsPlaceHolder.add(visToggleVols, bc)
-//        bc.insets = Insets(0, 0, 0, 20)
+        fourButtonsPlaceholder.add(visToggleVols, bc)
+        bc.gridx = 3
+        bc.insets = Insets(0, 20, 0, 0)
+        fourButtonsPlaceholder.add(visToggleTracks, bc)
 
         // -------------- button row --------------
         c.gridy++
-        c.gridx = 0
+        c.gridx = 1
         c.gridwidth = 1
-        c.anchor = GridBagConstraints.LINE_END
+        c.anchor = GridBagConstraints.EAST
+//        c.insets = Insets(0, 0, 10, 0)
         val closeBtn = JButton("Close")
         closeBtn.addActionListener { bridge.detachControllingUI() }
-        insertRColumnItem(closeBtn, c)
+//        insertRColumnItem(closeBtn, c)
+        controlsWindowPanel.add(closeBtn, c)
     }
 
     val sideSpace = 15
@@ -230,11 +251,15 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
 
     val toggleSpotsVisibility = ActionListener {
         val newState = !controlledBridge.sphereParent.visible
-        controlledBridge.setVisibilityOfSpots(newState)
+        controlledBridge.sphereParent.visible = newState
     }
     val toggleVolumeVisibility = ActionListener {
         val newState = !controlledBridge.volumeNode.visible
         controlledBridge.setVisibilityOfVolume(newState)
+    }
+    val toggleTrackVisivility = ActionListener {
+        val newState = !controlledBridge.linkParent.visible
+        controlledBridge.linkParent.visible = newState
     }
 
     val autoAdjustIntensity = ActionListener {
@@ -289,13 +314,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         bridge.updateVolAutomatically = updVolAutoBackup
     }
 
-    //int SOURCE_ID = 0;
-    //int SOURCE_USED_RES_LEVEL = 0;
-    lateinit var INTENSITY_CONTRAST: SpinnerModel
-    lateinit var INTENSITY_SHIFT: SpinnerModel
-    lateinit var INTENSITY_CLAMP_AT_TOP: SpinnerModel
-    lateinit var INTENSITY_GAMMA: SpinnerModel
-    lateinit var INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM: AdjustableBoundsRangeSlider
+
     val rangeSliderListener = ChangeListener {
         controlledBridge.intensity.rangeMin = INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM.value.toFloat()
         controlledBridge.intensity.rangeMax = INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM.upperValue.toFloat()
@@ -303,11 +322,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         controlledBridge.volumeNode.maxDisplayRange = controlledBridge.intensity.rangeMax
     }
 
-    //
-    lateinit var visToggleSpots: JButton
-    lateinit var visToggleVols: JButton
-    lateinit var autoIntensityBtn: JToggleButton
-    lateinit var lockGroupHandler: GroupLocksHandling
+
 
     init {
         this.controlledBridge = controlledBridge

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -27,6 +27,8 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
     lateinit var visToggleSpots: JButton
     lateinit var visToggleVols: JButton
     lateinit var visToggleTracks: JButton
+    lateinit var linkRangeBackwards: SpinnerModel
+    lateinit var linkRangeForwards: SpinnerModel
     lateinit var autoIntensityBtn: JToggleButton
     lateinit var lockGroupHandler: GroupLocksHandling
     lateinit var linkColorSelector: JComboBox<String>
@@ -124,6 +126,30 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         )
         INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM.addChangeListener(rangeSliderListener)
 
+
+        // links window range
+        c.gridy++
+        c.gridx = 0
+        insertLabel("Link window range backwards", c)
+        c.gridx = 1
+        linkRangeBackwards = SpinnerNumberModel(bridge.mastodon.maxTimepoint, 0, bridge.mastodon.maxTimepoint, 1)
+        insertSpinner(
+            linkRangeBackwards,
+            {f: Float -> bridge.sphereLinkNodes.linkBackwardRange = f.toInt()},
+            c)
+
+        c.gridy++
+        c.gridx = 0
+        insertLabel("Link window range forwards:", c)
+        c.gridx = 1
+        linkRangeForwards = SpinnerNumberModel(bridge.mastodon.maxTimepoint, 0, bridge.mastodon.maxTimepoint, 1)
+        insertSpinner(
+            linkRangeForwards,
+            {f: Float -> bridge.sphereLinkNodes.linkForwardRange = f.toInt()},
+            c
+        )
+
+
         // color parameters
         c.gridy++
         val colorPlaceholder = JPanel()
@@ -137,8 +163,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         // add the first choice of the list manually
         val linkColorChoices = mutableListOf("By Spot")
         // get the rest of the LUTs from sciview and clean up their names
-        val cb = controlledBridge ?: throw IllegalStateException("No initialized Sciview Bridge found!")
-        val availableLUTs = cb.sciviewWin.getAvailableLUTs() as MutableList<String>
+        val availableLUTs = bridge.sciviewWin.getAvailableLUTs() as MutableList<String>
         for (i in availableLUTs.indices) {
             availableLUTs[i] = availableLUTs[i].removeSuffix(".lut")
         }

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -4,7 +4,6 @@ import util.AdjustableBoundsRangeSlider
 import util.GroupLocksHandling
 import java.awt.*
 import java.awt.event.ActionListener
-import java.awt.event.ItemListener
 import java.util.function.Consumer
 import javax.swing.*
 import javax.swing.event.ChangeEvent
@@ -234,7 +233,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         controlledBridge.setVisibilityOfSpots(newState)
     }
     val toggleVolumeVisibility = ActionListener {
-        val newState = !controlledBridge.volChannelNode.visible
+        val newState = !controlledBridge.volumeNode.visible
         controlledBridge.setVisibilityOfVolume(newState)
     }
 
@@ -300,8 +299,8 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
     val rangeSliderListener = ChangeListener {
         controlledBridge.intensity.rangeMin = INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM.value.toFloat()
         controlledBridge.intensity.rangeMax = INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM.upperValue.toFloat()
-        controlledBridge.volChannelNode.minDisplayRange = controlledBridge.intensity.rangeMin
-        controlledBridge.volChannelNode.maxDisplayRange = controlledBridge.intensity.rangeMax
+        controlledBridge.volumeNode.minDisplayRange = controlledBridge.intensity.rangeMin
+        controlledBridge.volumeNode.maxDisplayRange = controlledBridge.intensity.rangeMax
     }
 
     //

--- a/src/main/kotlin/util/GroupLocksHandling.kt
+++ b/src/main/kotlin/util/GroupLocksHandling.kt
@@ -17,20 +17,14 @@ import sc.iview.event.NodeActivatedEvent
 class GroupLocksHandling(//controls sciview via this bridge obj
     private val bridge: SciviewBridge, mastodon: ProjectModel
 ) {
-    private val projectModel //controls Mastodon
-            : ProjectModel
-    private val vertices //shortcut to inside of Mastodon
-            : PoolCollectionWrapper<Spot>
+    //controls Mastodon
+    private val projectModel: ProjectModel = mastodon
+    //shortcut to inside of Mastodon
+    private val vertices: PoolCollectionWrapper<Spot> = projectModel.model.graph.vertices()
     private val navigationRequestsHandler: NavigationRequestsHandler = NavigationRequestsHandler()
     private val sciviewFocusHandler: SciviewEventListener = SciviewEventListener()
     private lateinit var myGroupHandle: GroupHandle
     private var isActive = false
-
-    init {
-        projectModel = mastodon
-        vertices = projectModel.model.graph.vertices()
-        //'cause it's not having any group handle yet
-    }
 
     fun createAndActivate(): GroupLocksPanel? {
         if (isActive) return null

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -39,7 +39,8 @@ class SphereLinkNodes
         events = sv.scijavaContext?.getService(EventService::class.java)
     }
 
-    val sphere = Icosphere(1f, 2)
+    val sphere = Icosphere(0.01f, 2)
+    lateinit var sphereInstance: InstancedNode
 
     fun initializeSpots(
         mastodonData: ProjectModel,
@@ -54,7 +55,7 @@ class SphereLinkNodes
             metallic = 0.0f
             roughness = 1.0f
         }
-        val sphereInstance = InstancedNode(sphere)
+        sphereInstance = InstancedNode(sphere)
 
         if (spotRef == null) spotRef = mastodonData.model.graph.vertexRef()
         val focusedSpotRef = mastodonData.focusModel.getFocusedVertex(spotRef)
@@ -70,12 +71,11 @@ class SphereLinkNodes
             inst.addAttribute(Material::class.java, sphere.material())
             s.localize(auxSpatialPos)
             inst.spatial {
-                position = Vector3f(auxSpatialPos) / parentNode.spatialOrNull()!!.scale - parentNode.spatialOrNull()!!.position
+                position = Vector3f(auxSpatialPos) * parentNode.spatialOrNull()!!.scale - parentNode.spatialOrNull()!!.position
             }
             inst.spatial().scale = Vector3f(
                 SCALE_FACTOR * sqrt(s.boundingSphereRadiusSquared).toFloat()
-            ) / parentNode.spatialOrNull()!!.scale
-
+            )
         }
     }
 
@@ -175,7 +175,8 @@ class SphereLinkNodes
         SCALE_FACTOR -= 0.1f
         if (SCALE_FACTOR < 0.1f) SCALE_FACTOR = 0.1f
         val factor = SCALE_FACTOR / oldScale
-        knownNodes.forEach { s: Sphere -> s.spatial().scale *= Vector3f(factor)  }
+//        knownNodes.forEach { s: Sphere -> s.spatial().scale *= Vector3f(factor)  }
+        sphereInstance.instances.forEach { s -> s.spatial().scale = Vector3f(factor) }
         logger.debug("Decreasing scale to $SCALE_FACTOR, by factor $factor")
     }
 
@@ -183,7 +184,8 @@ class SphereLinkNodes
         val oldScale = SCALE_FACTOR
         SCALE_FACTOR += 0.1f
         val factor = SCALE_FACTOR / oldScale
-        knownNodes.forEach { s: Sphere -> s.spatial().scale *= Vector3f(factor) }
+//        knownNodes.forEach { s: Sphere -> s.spatial().scale *= Vector3f(factor) }
+        sphereInstance.instances.forEach { s -> s.spatial().scale = Vector3f(factor) }
         logger.debug("Increasing scale to $SCALE_FACTOR, by factor $factor")
     }
 

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -42,7 +42,7 @@ class SphereLinkNodes
     /** Data class that combines the spatio-temporal index and the corresponding instance. */
     data class IndexedSpotInstance(val spot: Spot, val instance: InstancedNode.Instance)
 
-    val sphere = Icosphere(0.1f, 2)
+    val sphere = Icosphere(1f, 2)
     lateinit var mainInstance: InstancedNode
     lateinit var spots: SpatialIndex<Spot>
 

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -1,9 +1,6 @@
 package util
 
-import graphics.scenery.Blending
-import graphics.scenery.Node
-import graphics.scenery.RichNode
-import graphics.scenery.Sphere
+import graphics.scenery.*
 import graphics.scenery.primitives.Cylinder
 import graphics.scenery.utils.extensions.times
 import graphics.scenery.utils.lazyLogger
@@ -34,6 +31,32 @@ class SphereLinkNodes
 
     init {
         events = sv.scijavaContext?.getService(EventService::class.java)
+    }
+
+    val sphere = Icosphere(1f, 2)
+    val sphereInstance = InstancedNode(sphere)
+    val sphereParent = Group()
+
+    fun initializeSpots(
+        mastodonData: ProjectModel,
+        timepoint: Int,
+        colorizer: GraphColorGenerator<Spot, Link>
+    ) {
+        if (spotRef == null) spotRef = mastodonData.model.graph.vertexRef()
+        val focusedSpotRef = mastodonData.focusModel.getFocusedVertex(spotRef)
+        val spots = mastodonData.model.spatioTemporalIndex.getSpatialIndex(timepoint)
+        sv.blockOnNewNodes = false
+
+        var inst: InstancedNode.Instance
+        for (s in spots) {
+            inst = sphereInstance.addInstance()
+            s.localize(auxSpatialPos)
+            inst.spatial().setPosition(auxSpatialPos)
+            inst.spatial().scale = Vector3f(
+                SCALE_FACTOR * sqrt(s.boundingSphereRadiusSquared).toFloat()
+            )
+        }
+        sv.addNode(sphereInstance)
     }
 
     fun showTheseSpots(
@@ -69,9 +92,9 @@ class SphereLinkNodes
                 node.material().wireframe = true
             }
 
-            setupEmptyLinks()
-            registerNewSpot(s)
-            updateLinks(30, 30)
+//            setupEmptyLinks()
+//            registerNewSpot(s)
+//            updateLinks(30, 30)
 
             ++visibleNodeCount
         }
@@ -89,11 +112,6 @@ class SphereLinkNodes
                 knownNodes[i++].visible = false
             }
         }
-/*
-		logger.debug("Drawing currently in total "+visibleNodeCount
-				+ " and there are "+(knownNodes.size-visibleNodeCount)
-				+ " hidden...");
-*/
         return visibleNodeCount
     }
 

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -279,14 +279,14 @@ class SphereLinkNodes(
         when (colorMode) {
             SphereLinkNodes.colorMode.LUT -> {
                 for (link in links) {
-                    val factor = link.to.timepoint / numTimePoints.toDouble()
+                    val factor = link.tp / numTimePoints.toDouble()
                     val color = unpackRGB(lut.lookupARGB(0.0, 1.0, factor))
                     link.instance.instancedProperties["Color"] = { color }
                 }
             }
             SphereLinkNodes.colorMode.RAINBOW -> {
                 for (link in links) {
-                    val factor = (link.to.timepoint.toFloat() / numTimePoints.toFloat() * 360).toInt()
+                    val factor = (link.tp / numTimePoints.toFloat() * 360).toInt()
                     val color = hsvToArgb(factor, 100, 100)
                     link.instance.instancedProperties["Color"] = { color }
                 }
@@ -381,7 +381,7 @@ class SphereLinkNodes(
             }
             inst.name = from.label + " --> " + to.label
             inst.parent = linkParentNode
-            links.add(LinkNode(inst, from, to))
+            links.add(LinkNode(inst, from, to, from.timepoint))
 
             minTP = minTP.coerceAtMost(from.timepoint)
             maxTP = maxTP.coerceAtLeast(to.timepoint)
@@ -458,4 +458,4 @@ class SphereLinkNodes(
     }
 }
 
-data class LinkNode (val instance: InstancedNode.Instance, val from: Spot, val to: Spot)
+data class LinkNode (val instance: InstancedNode.Instance, val from: Spot, val to: Spot, val tp: Int)

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -65,9 +65,9 @@ class SphereLinkNodes
             //NB: also means that the knownNodes were fully exhausted
             knownNodes.addAll(addedExtraNodes)
             sv.publishNode(addedExtraNodes[0]) //NB: publishes only once
-            logger.info("Added ${addedExtraNodes.size} new spheres");
+            logger.info("Added ${addedExtraNodes.size} new spheres")
         } else {
-            logger.debug("Hide ${(knownNodes.size-visibleNodeCount)} spheres");
+            logger.debug("Hide ${(knownNodes.size-visibleNodeCount)} spheres")
             //NB: mark not-touched knownNodes as hidden
             var i = visibleNodeCount
             while (i < knownNodes.size) {
@@ -163,31 +163,31 @@ class SphereLinkNodes
 
         node.name = from.label + " --> " + to.label
         //node.setMaterial( linksNodesHub.getMaterial() );
-        println("add node : " + node.name)
+        logger.debug("add node : " + node.name)
         linksNodesHub?.addChild(node)
         links?.addLast(LinkNode(node, from.timepoint, to.timepoint))
 
-        minTP = Math.min(minTP, from.timepoint)
-        maxTP = Math.max(maxTP, to.timepoint)
+        minTP = minTP.coerceAtMost(from.timepoint)
+        maxTP = maxTP.coerceAtLeast(to.timepoint)
     }
 
     private fun forwardSearch(spot: Spot, toTP: Int) {
-        println("spot.getTimepoint():" + spot.timepoint)
-        println("TPtill:$toTP")
+        logger.debug("spot.getTimepoint():" + spot.timepoint)
+        logger.debug("TPtill:$toTP")
 
         if (spot.timepoint >= toTP) return
-        println("forward search!")
+        logger.debug("forward search!")
         //enumerate all forward links
         val s = spot.modelGraph.vertexRef()
         for (l in spot.incomingEdges()) {
-            println("forward search: incoming edges")
+            logger.debug("forward search: incoming edges")
             if (l.getSource(s).timepoint > spot.timepoint && s.timepoint <= toTP) {
                 addLink(spot, s)
                 forwardSearch(s, toTP)
             }
         }
         for (l in spot.outgoingEdges()) {
-            println("forward search: outgoing edges")
+            logger.debug("forward search: outgoing edges")
             if (l.getTarget(s).timepoint > spot.timepoint && s.timepoint <= toTP) {
                 addLink(spot, s)
                 forwardSearch(s, toTP)
@@ -201,14 +201,14 @@ class SphereLinkNodes
         //enumerate all backward links
         val s = spot.modelGraph.vertexRef()
         for (l in spot.incomingEdges()) {
-            println("backward search: incoming edges")
+            logger.debug("backward search: incoming edges")
             if (l.getSource(s).timepoint < spot.timepoint && s.timepoint >= fromTP) {
                 addLink(s, spot)
                 backwardSearch(s, fromTP)
             }
         }
         for (l in spot.outgoingEdges()) {
-            println("backward search: outgoing edges")
+            logger.debug("backward search: outgoing edges")
             if (l.getTarget(s).timepoint < spot.timepoint && s.timepoint >= fromTP) {
                 addLink(s, spot)
                 backwardSearch(s, fromTP)

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -25,6 +25,7 @@ import java.awt.Color
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.ArrayList
+import kotlin.math.PI
 import kotlin.math.sqrt
 import kotlin.time.TimeSource
 
@@ -150,7 +151,7 @@ class SphereLinkNodes(
             inst.spatial {
                 position = Vector3f(spotPosition)
                 scale = axisLengths * sphereScaleFactor
-                rotation = matrixToQuaternion(eigenvectors)
+                rotation = matrixToQuaternion(eigenvectors).rotationY((PI/2f).toFloat())
             }
             inst.setColorFromSpot(spot, colorizer)
             // highlight the spot currently selected in BDV
@@ -182,9 +183,9 @@ class SphereLinkNodes(
     private fun computeSemiAxes(eigenvalues: DoubleArray): Vector3f {
         return Vector3f(
             // flip X and Z axes to align with the sciview coordinate system (is this correct??)
-            sqrt(eigenvalues[2]).toFloat(),
+            sqrt(eigenvalues[0]).toFloat(),
             sqrt(eigenvalues[1]).toFloat(),
-            sqrt(eigenvalues[0]).toFloat()
+            sqrt(eigenvalues[2]).toFloat()
         )
     }
 

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -51,6 +51,8 @@ class SphereLinkNodes(
     var mainSpotInstance: InstancedNode? = null
     var mainLinkInstance: InstancedNode? = null
     lateinit var spots: SpatialIndex<Spot>
+    var linkForwardRange: Int
+    var linkBackwardRange: Int
 
     init {
         events = sv.scijavaContext?.getService(EventService::class.java)
@@ -58,6 +60,9 @@ class SphereLinkNodes(
 
         setLUT("Fire.lut")
         currentColorMode = colorMode.LUT
+
+        linkForwardRange = mastodonData.maxTimepoint
+        linkBackwardRange = mastodonData.maxTimepoint
     }
 
     fun setLUT(lutName: String) {
@@ -320,6 +325,13 @@ class SphereLinkNodes(
         }
         val end = TimeSource.Monotonic.markNow()
         logger.info("Link coloring took ${end - start}.")
+    }
+
+    fun updateLinkVisibility(currentTP: Int) {
+        links.forEach {link ->
+            // turns the link on if it is within range, otherwise turns it off
+            link.value.instance.visible = link.value.tp in currentTP - linkBackwardRange..currentTP + linkForwardRange
+        }
     }
 
     /** This function generates a unique hash for every spot, using its time-point and internal pool index. */

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -20,7 +20,6 @@ import sc.iview.SciView
 import sc.iview.event.NodeChangedEvent
 import java.util.*
 import kotlin.math.sqrt
-import kotlin.time.TimeSource
 
 
 //TODO FAILED to hook up here a 'parentNode' listener that would setVisible(false) on all children
@@ -40,112 +39,67 @@ class SphereLinkNodes
         events = sv.scijavaContext?.getService(EventService::class.java)
     }
 
-    /** Data class that combines the spatio-temporal index and the corresponding instance. */
-    data class IndexedSpotInstance(val spot: Spot, val instance: InstancedNode.Instance)
+    /** Data class that combines the mastodon spot, the corresponding instance and its time-point. */
+    data class IndexedSpotInstance(val spot: Spot, val instance: InstancedNode.Instance, val tp: Int)
 
     val sphere = Icosphere(1f, 2)
     lateinit var mainInstance: InstancedNode
     lateinit var spots: SpatialIndex<Spot>
 
-    /** Initializes the main spot instance, publishes it to the scene and populates it with instances from time-point 0. */
-    fun initializeInstancedSpots(
+    /** Shows or initializes the main spot instance, publishes it to the scene and populates it with instances from the current time-point. */
+    fun showInstancedSpots(
         mastodonData: ProjectModel,
         timepoint: Int,
-        colorizer: GraphColorGenerator<Spot, Link>
+        colorizer: GraphColorGenerator<Spot, Link>,
+        initializing: Boolean = false
     ) {
-        logger.debug("Initializing Spots")
-        sphere.setMaterial(ShaderMaterial.fromFiles("DeferredInstancedColor.vert", "DeferredInstancedColor.frag")) {
-            diffuse = Vector3f(1.0f, 1.0f, 1.0f)
-            ambient = Vector3f(1.0f, 1.0f, 1.0f)
-            specular = Vector3f(.0f, 1.0f, 1.0f)
-            metallic = 0.0f
-            roughness = 1.0f
+
+        if (initializing) {
+            logger.debug("Initializing Spots")
+            sphere.setMaterial(ShaderMaterial.fromFiles("DeferredInstancedColor.vert", "DeferredInstancedColor.frag")) {
+                diffuse = Vector3f(1.0f, 1.0f, 1.0f)
+                ambient = Vector3f(1.0f, 1.0f, 1.0f)
+                specular = Vector3f(.0f, 1.0f, 1.0f)
+                metallic = 0.0f
+                roughness = 1.0f
+            }
+
+            mainInstance = InstancedNode(sphere)
+            // Instanced properties should be aligned to 4*32bit boundaries, hence the use of Vector4f instead of Vector3f here
+            mainInstance.instancedProperties["Color"] = { Vector4f(1f) }
+            sv.addNode(mainInstance, parent = parentNode)
         }
-        mainInstance = InstancedNode(sphere)
-        // Instanced properties should be aligned to 4*32bit boundaries, hence the use of Vector4f instead of Vector3f here
-        mainInstance.instancedProperties["Color"] = { Vector4f(1f) }
+
         if (spotRef == null) spotRef = mastodonData.model.graph.vertexRef()
         val focusedSpotRef = mastodonData.focusModel.getFocusedVertex(spotRef)
         spots = mastodonData.model.spatioTemporalIndex.getSpatialIndex(timepoint)
         sv.blockOnNewNodes = false
 
-        sv.addNode(mainInstance, parent = parentNode)
         val covArray = Array(3) { DoubleArray(3) }
         var cov: Covariance
         var inst: InstancedNode.Instance
+
         for (s in spots) {
             inst = mainInstance.addInstance()
-            inst.name = "${s.internalPoolIndex}"
+            inst.name = "${timepoint}_${s.internalPoolIndex}"
             inst.addAttribute(Material::class.java, sphere.material())
             // add the instance to spotList, connected with the corresponding spatio-temporal index
-            spotList.add(IndexedSpotInstance(s, inst))
+            spotList.add(IndexedSpotInstance(s, inst, timepoint))
             s.localize(spotPosition)
             s.getCovariance(covArray)
             cov = Covariance(covArray)
             if (s.internalPoolIndex%5 == 0) {
                 logger.info("covariance for spot ${s.internalPoolIndex} is ${cov.covarianceMatrix}")
             }
-            inst.spatial {
-                position = Vector3f(spotPosition)
-            }
-            inst.spatial().scale = Vector3f(
-                SCALE_FACTOR * sqrt(s.boundingSphereRadiusSquared).toFloat()
-            )
+            inst.spatial().position = Vector3f(spotPosition)
+            inst.spatial().scale = Vector3f(SCALE_FACTOR * sqrt(s.boundingSphereRadiusSquared).toFloat())
             setInstancedSphereColor(inst, colorizer, s,false)
             inst.parent = parentNode
-            logger.info("initialized spot ${s.internalPoolIndex} at pos ${inst.spatial().position}")
-        }
-    }
-
-    fun updateInstancedSpots(
-        mastodonData: ProjectModel,
-        timepoint: Int,
-        colorizer: GraphColorGenerator<Spot, Link>
-    ) {
-        spots = mastodonData.model.spatioTemporalIndex.getSpatialIndex(timepoint)
-        logger.info("updating: got ${spots.size()} spots for timepoint $timepoint")
-        for (s in spots) {
-            s.localize(spotPosition)
-            val existingSpot = spotList.find { it.spot == s }
-//            logger.info("found spot ${s.internalPoolIndex}: ${existingSpot != null}")
-            if (existingSpot != null) {
-                logger.info("found spot ${s.internalPoolIndex} in existing spots")
-                // update existing spot
-                existingSpot.instance.visible = true
-                existingSpot.instance.spatial {
-                    position = Vector3f(spotPosition)
-                }
-                logger.info("updated existing spot ${s.internalPoolIndex} to pos ${existingSpot.instance.spatial().position}")
-            } else {
-                logger.info("added spot ${s.internalPoolIndex} to list because it didn't exist")
-                // create a new spot if none exists in spotList yet
-                val inst = mainInstance.addInstance()
-                inst.addAttribute(Material::class.java, sphere.material())
-                spotList.add(IndexedSpotInstance(s, inst))
-                inst.spatial {
-                    position = Vector3f(spotPosition)
-                }
-                setInstancedSphereColor(inst, colorizer, s,false)
-                inst.parent = parentNode
-                logger.info("added new spot ${s.internalPoolIndex} at pos ${inst.spatial().position}")
-            }
         }
 
-        // disable all left-over spots that exist in spotList but not in the current time-point
-//        val spotsToDisable = spotList.filter { inst ->
-//            !spots.any { spot -> spot == inst.spot }
-//        }
         for (s in spotList) {
-            val existingSpot = spots.find { it == s.spot }
-            if (existingSpot == null) {
-                s.instance.visible = false
-            }
+            s.instance.visible = s.tp == timepoint
         }
-//        logger.info("disabled ${spotsToDisable.size} spots")
-
-//        for (s in spotsToDisable) {
-//            s.instance.visible = false
-//        }
     }
 
     fun showTheseSpots(

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -47,16 +47,16 @@ class SphereLinkNodes
         val spots = mastodonData.model.spatioTemporalIndex.getSpatialIndex(timepoint)
         sv.blockOnNewNodes = false
 
+        sv.addNode(sphereInstance)
         var inst: InstancedNode.Instance
         for (s in spots) {
             inst = sphereInstance.addInstance()
             s.localize(auxSpatialPos)
-            inst.spatial().setPosition(auxSpatialPos)
+            inst.spatial().position = Vector3f(auxSpatialPos) / 100f
             inst.spatial().scale = Vector3f(
                 SCALE_FACTOR * sqrt(s.boundingSphereRadiusSquared).toFloat()
             )
         }
-        sv.addNode(sphereInstance)
     }
 
     fun showTheseSpots(

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -257,10 +257,18 @@ class SphereLinkNodes(
         }
     }
 
-    fun updateInstancedLinks (
+    fun updateInstancedLinkColors (
         colorizer: GraphColorGenerator<Spot, Link>
     ) {
-
+        var intColor = DEFAULT_COLOR
+        var color = Vector4f()
+        for (link in links) {
+            logger.info("got link color ${colorizer.color(link.from)} from TP ${link.from.timepoint} with inst ${link.instance.name}")
+            setInstancedSphereColor(link.instance, colorizer, link.from)
+//            intColor = colorizer.color(link.from)
+//            color = unpackRGB(intColor)
+//            link.instance.instancedProperties["Color"] = { color }
+        }
     }
 
 
@@ -302,9 +310,7 @@ class SphereLinkNodes(
 //        intCol = lut.lookupARGB(0.0, 1.0, to.timepoint / numTimePoints.toDouble())
         intColor = colorizer.color(from)
         color = unpackRGB(intColor)
-        logger.info("unpacked: $color")
 //        inst.instancedProperties["Color"] = { hsvToArgb((from.timepoint.toFloat() / numTimePoints.toFloat() * 100).toInt(), 100, 100) }
-        inst.instancedProperties["Color"] = { color }
         inst.spatial {
             scale.set(linkSize, posT.length().toDouble(), linkSize)
             rotation = Quaternionf().rotateTo(Vector3f(0f, 1f, 0f), posT).normalize()
@@ -313,7 +319,9 @@ class SphereLinkNodes(
 
         inst.name = from.label + " --> " + to.label
         inst.parent = linkParentNode
-        links.add(LinkNode(inst, from.timepoint, to.timepoint))
+//        inst.instancedProperties["Color"] = { color }
+        setInstancedSphereColor(inst, colorizer, from)
+        links.add(LinkNode(inst, from, to))
 
         minTP = minTP.coerceAtMost(from.timepoint)
         maxTP = maxTP.coerceAtLeast(to.timepoint)
@@ -386,7 +394,7 @@ class SphereLinkNodes(
         links.iterator().let {
             while (it.hasNext() == true) {
                 val link = it.next()
-                if (link.fromTP < fromTP || link.toTP > toTP) {
+                if (link.from.timepoint < fromTP || link.to.timepoint > toTP) {
                     linksNodesHub?.removeChild(link.instance)
                     it.remove()
                 }
@@ -415,4 +423,4 @@ class SphereLinkNodes(
     }
 }
 
-data class LinkNode (var instance: InstancedNode.Instance, var fromTP: Int, var toTP: Int)
+data class LinkNode (var instance: InstancedNode.Instance, var from: Spot, var to: Spot)

--- a/src/test/kotlin/org/mastodon/mamut/StartSciviewBridgeDirectly.kt
+++ b/src/test/kotlin/org/mastodon/mamut/StartSciviewBridgeDirectly.kt
@@ -39,12 +39,14 @@ object StartSciviewBridgeDirectly {
             //point this to your testing project, or grab example project with:
             //git clone https://github.com/mastodon-sc/mastodon-example-data.git
             //String projectPath = "/home/ulman/Mette/e1/E1_reduced.mastodon";
-            val projectPath = "/home/ulman/devel/sciview_hack2/mastodon-example-data/tgmm-mini/tgmm-mini.mastodon"
+//            val projectPath = "/home/ulman/devel/sciview_hack2/mastodon-example-data/tgmm-mini/tgmm-mini.mastodon"
+            val projectPath = "D:/CASUS/datasets/mastodon-example-data/tgmm-mini/tgmm-mini.mastodon"
             // --------------->>  <<---------------
             val sv = createSciview()
             val mastodon = giveMeMastodonOfThisProject(sv.scijavaContext, projectPath)
-            val bridge = SciviewBridge(mastodon, 0, 2, sv)
-            //bridge.openSyncedBDV();
+            val bridge = SciviewBridge(mastodon, targetSciviewWindow = sv)
+            bridge.createAndShowControllingUI()
+            bridge.openSyncedBDV();
             mastodon.projectClosedListeners().add(CloseListener {
                 logger.debug("Mastodon project was closed, cleaning up in sciview:")
                 bridge.close() //calls also bridge.detachControllingUI();


### PR DESCRIPTION
This PR adds support to show links from the BDV window inside sciview and color them using LUTs. It also fixes the volume loading and scaling by using the source and converter type instead of directly accessing the RAI images. This allows us to use the `Volume.goToTimepoint` method for convenience.
The PR also streamlines the keyboard handler registrations and it changes the geometry rendering from conventional objects per spot to instanced geometry (used for spots and links). This greatly speeds up render times, at the cost of not being able to select individual spots. But that is a problem for future Samuel.