### PR TITLE
Exchange Mastodon API with ELEPHANT API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
     implementation("org.slf4j:slf4j-simple:1.7.36")
 
-    implementation("org.mastodon:mastodon:1.0.0-beta-28")
+    implementation("com.github.elephant-track:elephant-client:0.5.0")
 
     implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.1")

--- a/src/test/kotlin/org/mastodon/mamut/StartSciviewBridgeDirectly.kt
+++ b/src/test/kotlin/org/mastodon/mamut/StartSciviewBridgeDirectly.kt
@@ -40,7 +40,7 @@ object StartSciviewBridgeDirectly {
             //git clone https://github.com/mastodon-sc/mastodon-example-data.git
             //String projectPath = "/home/ulman/Mette/e1/E1_reduced.mastodon";
 //            val projectPath = "/home/ulman/devel/sciview_hack2/mastodon-example-data/tgmm-mini/tgmm-mini.mastodon"
-            val projectPath = "D:/CASUS/datasets/mastodon-example-data/tgmm-mini/tgmm-mini.mastodon"
+            val projectPath = "C:/Software/datasets/mastodon-example-data/tgmm-mini/tgmm-mini.mastodon"
             // --------------->>  <<---------------
             val sv = createSciview()
             val mastodon = giveMeMastodonOfThisProject(sv.scijavaContext, projectPath)


### PR DESCRIPTION
Luckily, the ELEPHANT API is just a drop-in replacement for the Mastodon API.