### PR TITLE
Eyetracking meets mastodon

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
     implementation("org.slf4j:slf4j-simple:1.7.36")
 
-    implementation("org.mastodon:mastodon:1.0.0-beta-28")
+    implementation("com.github.elephant-track:elephant-client:0.5.0")
 
     implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.1")

--- a/src/main/kotlin/BdvNotifier.kt
+++ b/src/main/kotlin/BdvNotifier.kt
@@ -81,7 +81,7 @@ class BdvNotifier(
         TimePointListener, GraphChangeListener, VertexPositionListener<Spot>, PropertyChangeListener, FocusListener,
         ColoringChangedListener {
         override fun graphChanged() {
-            logger.info("Called graphChanged")
+            logger.debug("Called graphChanged")
             timeStampOfLastEvent = System.currentTimeMillis()
             isLastGraphEventValid = true
         }

--- a/src/main/kotlin/BdvNotifier.kt
+++ b/src/main/kotlin/BdvNotifier.kt
@@ -5,6 +5,7 @@ import bdv.viewer.TransformListener
 import graphics.scenery.utils.lazyLogger
 import net.imglib2.realtransform.AffineTransform3D
 import org.mastodon.graph.GraphChangeListener
+import org.mastodon.graph.GraphListener
 import org.mastodon.mamut.model.Spot
 import org.mastodon.mamut.views.bdv.MamutViewBdv
 import org.mastodon.model.FocusListener
@@ -80,7 +81,7 @@ class BdvNotifier(
         TimePointListener, GraphChangeListener, VertexPositionListener<Spot>, PropertyChangeListener, FocusListener,
         ColoringChangedListener {
         override fun graphChanged() {
-            logger.debug("Called graphChanged")
+            logger.info("Called graphChanged")
             timeStampOfLastEvent = System.currentTimeMillis()
             isLastGraphEventValid = true
         }
@@ -166,7 +167,7 @@ class BdvNotifier(
             logger.debug("$SERVICE_NAME started")
             try {
                 while (keepWatching) {
-                    if ((eventsSource.isLastContentEventValid || eventsSource.isLastVertexEventValid
+                    if ((eventsSource.isLastContentEventValid || eventsSource.isLastVertexEventValid || eventsSource.isLastGraphEventValid
                         || eventsSource.isLastViewEventValid &&
                         System.currentTimeMillis() - eventsSource.timeStampOfLastEvent > updateInterval)
                         && !lockVertexUpdates

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -135,7 +135,7 @@ class SciviewBridge: TimepointObserver {
 
         //add "root" with data axes
         axesParent = addDataAxes()
-        sciviewWin.addNode<Node?>(axesParent)
+        sciviewWin.addNode(axesParent)
 
         //get necessary metadata - from image data
         this.sourceID = sourceID
@@ -600,6 +600,11 @@ class SciviewBridge: TimepointObserver {
         eyeTracking.unregisterObserver(this)
         logger.info("Removed timepoint observer from VR bindings.")
         eyeTracking.stop()
+        // ensure that the volume is visible again (could be turned invisible during the calibration)
+        volumeNode.visible = true
+        sciviewWin.centerOnNode(axesParent)
+        sciviewWin.requestPropEditorRefresh()
+        registerKeyboardHandlers()
     }
 
     /** Implementation of the [TimepointObserver] interface; this method is called whenever the VR user triggers

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -39,6 +39,7 @@ import sc.iview.SciView
 import sc.iview.commands.demo.advanced.EyeTracking
 import util.SphereLinkNodes
 import javax.swing.JFrame
+import kotlin.concurrent.thread
 import kotlin.math.*
 
 class SciviewBridge {
@@ -575,17 +576,19 @@ class SciviewBridge {
     }
 
     fun launchEyeTracking() {
-        eyeTracking = EyeTracking(
-            sphereLinkNodes.addLinkToMastodon,
-            {
-                logger.info("called mastodonUpdateGraph")
-                updateSciviewContent(bdvWinParamsProvider!!)
-                sphereLinkNodes.prevVertex = null
-                sphereLinkNodes.showInstancedLinks(sphereLinkNodes.currentColorMode, bdvWinParamsProvider!!.colorizer)
-            },
-            sciviewWin
-        )
-        eyeTracking.run()
+        thread {
+            eyeTracking = EyeTracking(
+                sphereLinkNodes.addLinkToMastodon,
+                {
+                    logger.info("called mastodonUpdateGraph")
+                    updateSciviewContent(bdvWinParamsProvider!!)
+                    sphereLinkNodes.prevVertex = null
+                    sphereLinkNodes.showInstancedLinks(sphereLinkNodes.currentColorMode, bdvWinParamsProvider!!.colorizer)
+                },
+                sciviewWin
+            )
+            eyeTracking.run()
+        }
     }
 
     fun stopEyeTracking() {

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -309,13 +309,17 @@ class SciviewBridge {
             bdvWinParamsProvider?.let {
                 updateSciviewContent(it)
                 bdvNotifier = BdvNotifier(
+                    // time point processor
                     { updateSciviewContent(it) },
+                    // view update processor
                     { updateSciviewCamera(bdvWin) },
+                    // vertex update processor
                     moveSpotInSciview as (Spot?) -> Unit,
-                    // update graph routine: this redraws the track segments and resets the stored previous vertex to be empty
-                    { sphereLinkNodes.showInstancedLinks(sphereLinkNodes.currentColorMode, it.colorizer)
-                    sphereLinkNodes.prevVertex = null
-                    logger.info("sphereLinkNodes.prevVertex is now ${sphereLinkNodes.prevVertex}, should be null")},
+                    // graph update processor: redraws track segments and spots
+                    {
+                        sphereLinkNodes.showInstancedLinks(sphereLinkNodes.currentColorMode, it.colorizer)
+                        sphereLinkNodes.showInstancedSpots(it.timepoint, it.colorizer)
+                    },
                     mastodon,
                     bdvWin
                 )

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -579,9 +579,15 @@ class SciviewBridge {
         argMap["mastodonUpdateGraph"] = {
             logger.info("called mastodonUpdateGraph")
             updateSciviewContent(bdvWinParamsProvider!!)
+            sphereLinkNodes.prevVertex = null
             sphereLinkNodes.showInstancedLinks(sphereLinkNodes.currentColorMode, bdvWinParamsProvider!!.colorizer)
         }
         command.run(EyeTrackingDemo::class.java, true, argMap)
+    }
+
+    fun stopEyeTracking() {
+        sciviewWin.toggleVRRendering()
+        sciviewWin.deleteNode(sciviewWin.find("shell"))
     }
 
 

--- a/src/main/kotlin/SciviewBridge.kt
+++ b/src/main/kotlin/SciviewBridge.kt
@@ -324,7 +324,8 @@ class SciviewBridge {
                     moveSpotInSciview as (Spot?) -> Unit,
                     // update graph routine: this redraws the track segments and resets the stored previous vertex to be empty
                     { sphereLinkNodes.showInstancedLinks(sphereLinkNodes.currentColorMode, it.colorizer)
-                    sphereLinkNodes.prevVertex = null},
+                    sphereLinkNodes.prevVertex = null
+                    logger.info("sphereLinkNodes.prevVertex is now ${sphereLinkNodes.prevVertex}, should be null")},
                     mastodon,
                     bdvWin
                 )
@@ -334,6 +335,7 @@ class SciviewBridge {
     private var recentTagSet: TagSetStructure.TagSet? = null
     var recentColorizer: GraphColorGenerator<Spot, Link>? = null
     val noTSColorizer = DefaultGraphColorGenerator<Spot, Link>()
+
     private fun getCurrentColorizer(forThisBdv: MamutViewBdv): GraphColorGenerator<Spot, Link> {
         //NB: trying to avoid re-creating of new TagSetGraphColorGenerator objs with every new content rending
         val colorizer: GraphColorGenerator<Spot, Link>
@@ -441,6 +443,11 @@ class SciviewBridge {
                 .filter { c: Node -> c.name.startsWith("Bounding") }
                 .forEach { c: Node -> c.visible = false }
         }
+    }
+
+    /** Sets the detail level of the volume node. */
+    fun setMipmapLevel(level: Float) {
+        volumeNode.multiResolutionLevelLimits = level.toInt() to level.toInt() + 1
     }
 
     fun focusSpot(name: String) {

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -24,6 +24,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
     lateinit var INTENSITY_CLAMP_AT_TOP: SpinnerModel
     lateinit var INTENSITY_GAMMA: SpinnerModel
     lateinit var INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM: AdjustableBoundsRangeSlider
+    lateinit var MIPMAP_LEVEL: SpinnerNumberModel
     //
     lateinit var visToggleSpots: JButton
     lateinit var visToggleVols: JButton
@@ -107,6 +108,21 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
             c
         )
 
+        // MIPMAP levels
+        c.gridy++
+        c.gridx = 0
+        insertLabel("Choose Mipmap Level", c)
+        c.gridx = 1
+        MIPMAP_LEVEL = SpinnerNumberModel(0, 0, 6, 1)
+        insertSpinner(MIPMAP_LEVEL, { level: Float ->
+            controlledBridge?.let {
+                // update the UI spinner to allow spinning up to the mipmap level found in the volume
+                // subtract 1 to go from range 0 to max
+                it.associatedUI?.setMaxMipmapLevel(it.sac.spimSource.numMipmapLevels - 1)
+                it.setMipmapLevel(level)
+            }
+        }, c)
+
         // -------------- separator --------------
         c.gridy++
         insertSeparator(c)
@@ -126,7 +142,6 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
             10000
         )
         INTENSITY_RANGE_MINMAX_CTRL_GUI_ELEM.addChangeListener(rangeSliderListener)
-
 
         // links window range
         c.gridy++
@@ -158,7 +173,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         )
 
 
-        // color parameters
+        // ----------- color parameters --------------
         c.gridy++
         c.gridwidth = 4
         val colorPlaceholder = JPanel()
@@ -228,7 +243,7 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         buttonRow.insets = Insets(0, 20, 0, 0)
         fourButtonsPlaceholder.add(visToggleTracks, buttonRow)
 
-        // -------------- close button row --------------
+        // ---------- Eye Tracking Button ---------------
         c.gridy++
         c.gridx = 1
         c.gridwidth = 1
@@ -236,16 +251,25 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         val eyetrackingButton = JButton("Start Eye Tracking")
         eyetrackingButton.addActionListener { bridge.launchEyeTracking() }
         controlsWindowPanel.add(eyetrackingButton, c)
-        c.insets = Insets(0, 20, 0, 0)
-        c.gridx = 2
+
+        // -------------- close button row --------------
+        c.gridy++
+        c.gridx = 1
+        c.gridwidth = 1
         val closeBtn = JButton("Close")
         closeBtn.addActionListener { bridge.detachControllingUI() }
-        c.insets = Insets(0, 0, 0, 15)
+        c.insets = Insets(0, 0, 15, 15)
         controlsWindowPanel.add(closeBtn, c)
+    }
+
+    /** Sets the maximum mipmap level found in the volume node as the spinner's max value. */
+    fun setMaxMipmapLevel(level: Int) {
+        MIPMAP_LEVEL.maximum = level
     }
 
     val sideSpace = 15
     val noteSpace = Insets(2, sideSpace, 8, 2 * sideSpace)
+
     fun insertNote(noteText: String?, c: GridBagConstraints) {
         val prevGridW = c.gridwidth
         val prevInsets = c.insets

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -377,16 +377,24 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
     }
 
     val toggleSpotsVisibility = ActionListener {
-        val newState = !controlledBridge.sphereParent.visible
-        controlledBridge.sphereParent.visible = newState
+        val spots = controlledBridge.volumeNode.getChildrenByName("SpotInstance").first()
+        val newState = !spots.visible
+        spots.visible = newState
     }
     val toggleVolumeVisibility = ActionListener {
+        val spots = controlledBridge.volumeNode.getChildrenByName("SpotInstance").first()
+        val spotVis = spots.visible
+        val links = controlledBridge.volumeNode.getChildrenByName("LinkInstance").first()
+        val linksVis = links.visible
         val newState = !controlledBridge.volumeNode.visible
         controlledBridge.setVisibilityOfVolume(newState)
+        spots.visible = spotVis
+        links.visible = linksVis
     }
     val toggleTrackVisivility = ActionListener {
-        val newState = !controlledBridge.linkParent.visible
-        controlledBridge.linkParent.visible = newState
+        val links = controlledBridge.volumeNode.getChildrenByName("LinkInstance").first()
+        val newState = !links.visible
+        links.visible = newState
     }
 
     val autoAdjustIntensity = ActionListener {

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -233,9 +233,14 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         c.gridx = 1
         c.gridwidth = 1
         c.anchor = GridBagConstraints.EAST
+        val eyetrackingButton = JButton("Start Eye Tracking")
+        eyetrackingButton.addActionListener { bridge.launchEyeTracking() }
+        controlsWindowPanel.add(eyetrackingButton, c)
+        c.insets = Insets(0, 20, 0, 0)
+        c.gridx = 2
         val closeBtn = JButton("Close")
         closeBtn.addActionListener { bridge.detachControllingUI() }
-        c.insets = Insets(0, 0, 10, 15)
+        c.insets = Insets(0, 0, 0, 15)
         controlsWindowPanel.add(closeBtn, c)
     }
 

--- a/src/main/kotlin/SciviewBridgeUI.kt
+++ b/src/main/kotlin/SciviewBridgeUI.kt
@@ -8,7 +8,6 @@ import java.awt.*
 import java.awt.event.ActionListener
 import java.util.function.Consumer
 import javax.swing.*
-import javax.swing.border.EmptyBorder
 import javax.swing.event.ChangeEvent
 import javax.swing.event.ChangeListener
 
@@ -35,6 +34,8 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
     lateinit var lockGroupHandler: GroupLocksHandling
     lateinit var linkColorSelector: JComboBox<String>
     lateinit var volumeColorSelector: JComboBox<String>
+    lateinit var startEyeTracking: JButton
+    lateinit var stopEyeTracking: JButton
 
     // -------------------------------------------------------------------------------------------
     private fun populatePane() {
@@ -222,35 +223,46 @@ class SciviewBridgeUI(controlledBridge: SciviewBridge, populateThisContainer: Co
         autoIntensityBtn = JToggleButton("Auto Intensity", bridge.isVolumeAutoAdjust)
         autoIntensityBtn.addActionListener(autoAdjustIntensity)
         //
-        val fourButtonsPlaceholder = JPanel()
-        controlsWindowPanel.add(fourButtonsPlaceholder, c)
+        val visButtonsPlaceholder = JPanel()
+        controlsWindowPanel.add(visButtonsPlaceholder, c)
         //
-        fourButtonsPlaceholder.setLayout(GridBagLayout())
-        val buttonRow = GridBagConstraints()
-        buttonRow.fill = GridBagConstraints.HORIZONTAL
-        buttonRow.anchor = GridBagConstraints.WEST
-        buttonRow.weightx = 0.4
-        buttonRow.gridx = 0
+        visButtonsPlaceholder.setLayout(GridBagLayout())
+        val visButtonRow = GridBagConstraints()
+        visButtonRow.fill = GridBagConstraints.HORIZONTAL
+        visButtonRow.anchor = GridBagConstraints.WEST
+        visButtonRow.weightx = 0.4
+        visButtonRow.gridx = 0
 //        bc.insets = Insets(0, 20, 0, 0)
-        fourButtonsPlaceholder.add(autoIntensityBtn, buttonRow)
-        buttonRow.gridx = 1
-        buttonRow.insets = Insets(0, 20, 0, 0)
-        fourButtonsPlaceholder.add(visToggleSpots, buttonRow)
-        buttonRow.gridx = 2
-        buttonRow.insets = Insets(0, 20, 0, 0)
-        fourButtonsPlaceholder.add(visToggleVols, buttonRow)
-        buttonRow.gridx = 3
-        buttonRow.insets = Insets(0, 20, 0, 0)
-        fourButtonsPlaceholder.add(visToggleTracks, buttonRow)
+        visButtonsPlaceholder.add(autoIntensityBtn, visButtonRow)
+        visButtonRow.gridx = 1
+        visButtonRow.insets = Insets(0, 20, 0, 0)
+        visButtonsPlaceholder.add(visToggleSpots, visButtonRow)
+        visButtonRow.gridx = 2
+        visButtonRow.insets = Insets(0, 20, 0, 0)
+        visButtonsPlaceholder.add(visToggleVols, visButtonRow)
+        visButtonRow.gridx = 3
+        visButtonRow.insets = Insets(0, 20, 0, 0)
+        visButtonsPlaceholder.add(visToggleTracks, visButtonRow)
 
-        // ---------- Eye Tracking Button ---------------
+        // ---------- Eye Tracking Buttons ---------------
         c.gridy++
-        c.gridx = 1
-        c.gridwidth = 1
-        c.anchor = GridBagConstraints.EAST
-        val eyetrackingButton = JButton("Start Eye Tracking")
-        eyetrackingButton.addActionListener { bridge.launchEyeTracking() }
-        controlsWindowPanel.add(eyetrackingButton, c)
+
+        startEyeTracking = JButton("Start Eye Tracking")
+        startEyeTracking.addActionListener { bridge.launchEyeTracking() }
+        stopEyeTracking = JButton("Stop Eye Tracking")
+        stopEyeTracking.addActionListener { bridge.stopEyeTracking() }
+
+        val trackingBtnPlaceholder = JPanel()
+        controlsWindowPanel.add(trackingBtnPlaceholder, c)
+        val trackButtonRow = GridBagConstraints()
+        trackButtonRow.fill = GridBagConstraints.HORIZONTAL
+        trackButtonRow.anchor = GridBagConstraints.WEST
+        trackButtonRow.weightx = 0.2
+        trackButtonRow.gridx = 0
+        trackingBtnPlaceholder.add(startEyeTracking, trackButtonRow)
+        trackButtonRow.gridx = 1
+        trackButtonRow.insets = Insets(0, 20, 0, 0)
+        trackingBtnPlaceholder.add(stopEyeTracking, trackButtonRow)
 
         // -------------- close button row --------------
         c.gridy++

--- a/src/main/kotlin/util/GroupLocksHandling.kt
+++ b/src/main/kotlin/util/GroupLocksHandling.kt
@@ -52,11 +52,11 @@ class GroupLocksHandling(//controls sciview via this bridge obj
 
     internal inner class NavigationRequestsHandler : NavigationListener<Spot, Link>, TimepointListener {
         override fun navigateToVertex(vertex: Spot) {
-            if (isActive) focusSciviewToNode(vertex.label)
+//            if (isActive) focusSciviewToNode(vertex.label)
         }
 
         override fun navigateToEdge(edge: Link) {
-            if (isActive) focusSciviewToNode(edge.source.label)
+//            if (isActive) focusSciviewToNode(edge.source.label)
         }
 
         override fun timepointChanged() {
@@ -79,9 +79,5 @@ class GroupLocksHandling(//controls sciview via this bridge obj
             //TODO: this is triggering also our handler (see above navigateToVertex()) !
             myGroupHandle.getModel(projectModel.NAVIGATION).notifyNavigateToVertex(res.get())
         }
-    }
-
-    fun focusSciviewToNode(name: String) {
-        bridge.focusSpot(name)
     }
 }

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -621,6 +621,7 @@ class SphereLinkNodes(
         v.init(spineVertex.timepoint, pos, 1.0)
         if (prevVertex != null) {
             val e = mastodonData.model.graph.addEdge(prevVertex, v)
+            e.init()
             mastodonData.model.graph.notifyGraphChanged()
         }
         prevVertex = v

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -130,7 +130,7 @@ class SphereLinkNodes(
         var axisLengths: Vector3f
 
         var index = 0
-        logger.info("we have ${spots.size()} spots in this Mastodon time point.")
+        logger.debug("we have ${spots.size()} spots in this Mastodon time point.")
         for (spot in spots) {
             // reuse a spot instance from the pool if the pool is large enough
             if (index < spotPool.size) {
@@ -177,7 +177,7 @@ class SphereLinkNodes(
             spotPool[i++].visible = false
         }
         val tElapsed = TimeSource.Monotonic.markNow() - tStart
-        logger.info("Spot updates took $tElapsed")
+        logger.debug("Spot updates took $tElapsed")
     }
 
     private fun computeEigen(covariance: Array2DRowRealMatrix): Pair<DoubleArray, RealMatrix> {
@@ -518,7 +518,6 @@ class SphereLinkNodes(
             }
             // otherwise create a new instance and add it to the pool
             else {
-                logger.info("adding new link to the pool for whatever reason")
                 inst = mainLink.addInstance()
                 inst.addAttribute(Material::class.java, cylinder.material())
                 inst.parent = linkParentNode

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -45,8 +45,8 @@ class SphereLinkNodes(
     var numTimePoints: Int
     lateinit var lut: ColorTable
     var currentColorMode: ColorMode
-    val spotPool: MutableList<InstancedNode.Instance> = mutableListOf()
-    val linkPool: MutableList<InstancedNode.Instance> = mutableListOf()
+    val spotPool: MutableList<InstancedNode.Instance> = ArrayList(10000)
+    val linkPool: MutableList<InstancedNode.Instance> = ArrayList(10000)
     private var spotRef: Spot? = null
     var events: EventService? = null
 
@@ -103,8 +103,8 @@ class SphereLinkNodes(
             mainSpot.instancedProperties["Color"] = { Vector4f(1f) }
 
             // initialize the whole pool with instances once
-            for (i in spotPool.indices) {
-                spotPool[i] = mainSpot.addInstance()
+            for (i in 0..<10000) {
+                spotPool.add(mainSpot.addInstance())
             }
 
             sv.addNode(mainSpot, parent = sphereParentNode)
@@ -485,8 +485,8 @@ class SphereLinkNodes(
             mainLink.instancedProperties["Color"] = { Vector4f(1f) }
 
             // initialize the whole pool with instances once
-            for (i in linkPool.indices) {
-                linkPool[i] = mainLink.addInstance()
+            for (i in 0..<10000) {
+                linkPool.add(mainLink.addInstance())
             }
 
             sv.addNode(mainLink, parent = linkParentNode)

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -100,13 +100,13 @@ class SphereLinkNodes(
             }
 
             val mainSpot = InstancedNode(sphere)
+            mainSpot.name = "SpotInstance"
             // Instanced properties should be aligned to 4*32bit boundaries, hence the use of Vector4f instead of Vector3f here
             mainSpot.instancedProperties["Color"] = { Vector4f(1f) }
             var inst: InstancedNode.Instance
             // initialize the whole pool with instances once
             for (i in 0..<10000) {
                 inst = mainSpot.addInstance()
-                inst.addAttribute(Material::class.java, sphere.material())
                 inst.parent = sphereParentNode
                 spotPool.add(inst)
             }
@@ -140,7 +140,6 @@ class SphereLinkNodes(
             // otherwise create a new instance and add it to the pool
             else {
                 inst = mainSpot.addInstance()
-                inst.addAttribute(Material::class.java, sphere.material())
                 inst.parent = sphereParentNode
                 spotPool.add(inst)
             }
@@ -154,7 +153,7 @@ class SphereLinkNodes(
 
             inst.spatial {
                 position = Vector3f(spotPosition)
-                scale = Vector3f(sphereScaleFactor *  sqrt(spot.boundingSphereRadiusSquared.toFloat()) / 50f)
+                scale = Vector3f(sphereScaleFactor *  sqrt(spot.boundingSphereRadiusSquared.toFloat()) / 10f)
                 // TODO add ellipsoid scale & rotation to instances
                 // scale = axisLengths * sphereScaleFactor * 0.5f
                 // rotation = eigenvectors.toQuaternion()
@@ -487,6 +486,7 @@ class SphereLinkNodes(
                 roughness = 1.0f
             }
             val mainLink = InstancedNode(cylinder)
+            mainLink.name = "LinkInstance"
             mainLink.instancedProperties["Color"] = { Vector4f(1f) }
 
             // initialize the whole pool with instances once
@@ -519,7 +519,7 @@ class SphereLinkNodes(
             // otherwise create a new instance and add it to the pool
             else {
                 inst = mainLink.addInstance()
-                inst.addAttribute(Material::class.java, cylinder.material())
+//                inst.addAttribute(Material::class.java, cylinder.material())
                 inst.parent = linkParentNode
                 linkPool.add(inst)
             }

--- a/src/main/kotlin/util/SphereLinkNodes.kt
+++ b/src/main/kotlin/util/SphereLinkNodes.kt
@@ -617,7 +617,7 @@ class SphereLinkNodes(
         val v = mastodonData.model.graph.addVertex()
         val pos = spineVertex.position.toFloatArray().map { it.toDouble() }.toDoubleArray()
 
-        v.init(spineVertex.timepoint, pos, 1.0)
+        v.init(spineVertex.timepoint, pos, 20.0)
         if (prevVertex != null) {
             val e = mastodonData.model.graph.addEdge(prevVertex, v)
             e.init()

--- a/src/test/kotlin/SphericalDatasetGenerator.kt
+++ b/src/test/kotlin/SphericalDatasetGenerator.kt
@@ -74,8 +74,9 @@ class SphericalDatasetGenerator {
             }
         }
 
-        // Display the result
-        ImageJFunctions.show(img, "3D+time Spherical Dataset")
+        val imp = ImageJFunctions.wrap(img, "3D+time Spherical Dataset")
+        imp.setDimensions(1, depth.toInt(), frames.toInt())
+        imp.show()
 
         println("3D+time dataset created with dimensions: ${Intervals.dimensionsAsLongArray(img).contentToString()}")
     }

--- a/src/test/kotlin/SphericalDatasetGenerator.kt
+++ b/src/test/kotlin/SphericalDatasetGenerator.kt
@@ -1,0 +1,82 @@
+import net.imagej.ImageJ
+import net.imglib2.Cursor
+import net.imglib2.RandomAccessibleInterval
+import net.imglib2.img.display.imagej.ImageJFunctions
+import net.imglib2.img.imageplus.ImagePlusImg
+import net.imglib2.img.imageplus.ImagePlusImgFactory
+import net.imglib2.type.numeric.real.FloatType
+import net.imglib2.util.Intervals
+import net.imglib2.view.Views
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+/** This class creates a synthetic dataset of a sphere with linear falloff
+ *
+ * */
+class SphericalDatasetGenerator {
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            // Open an ImageJ window
+            val ij = ImageJ()
+
+            // Run the example
+            SphericalDatasetGenerator().run()
+
+            // Display the ImageJ window
+            ij.ui().showUI()
+        }
+    }
+
+    fun run() {
+        // Define dimensions
+        val width = 100L
+        val height = 100L
+        val depth = 100L
+        val frames = 50L
+
+        // Create 4D image (3D + time) using ImagePlusImgFactory
+        val img: ImagePlusImg<FloatType, *> = ImagePlusImgFactory(FloatType()).create(width, height, depth, frames)
+
+        // Define sphere parameters
+        val radius = 20.0
+        val centerX = width / 2.0
+        val centerY = height / 2.0
+        val centerZ = depth / 2.0
+        val moveSpeed = 1.0 // Speed of movement per frame
+
+        // Generate the dataset
+        for (t in 0 until frames) {
+            val offsetX = t * moveSpeed - 20
+            val frame: RandomAccessibleInterval<FloatType> = Views.hyperSlice(img, 3, t)
+
+            val cursor: Cursor<FloatType> = Views.iterable(frame).cursor()
+
+            while (cursor.hasNext()) {
+                cursor.fwd()
+                val x = cursor.getDoublePosition(0)
+                val y = cursor.getDoublePosition(1)
+                val z = cursor.getDoublePosition(2)
+
+                val distance = sqrt(
+                    (x - centerX - offsetX).pow(2) +
+                            (y - centerY).pow(2) +
+                            (z - centerZ).pow(2)
+                )
+
+                val intensity = if (distance <= radius) {
+                    (1 - distance / radius).coerceIn(0.0, 1.0)
+                } else {
+                    0.0
+                }
+
+                cursor.get().set(intensity.toFloat())
+            }
+        }
+
+        // Display the result
+        ImageJFunctions.show(img, "3D+time Spherical Dataset")
+
+        println("3D+time dataset created with dimensions: ${Intervals.dimensionsAsLongArray(img).contentToString()}")
+    }
+}

--- a/src/test/kotlin/SphericalDatasetGenerator.kt
+++ b/src/test/kotlin/SphericalDatasetGenerator.kt
@@ -7,6 +7,7 @@ import net.imglib2.img.imageplus.ImagePlusImgFactory
 import net.imglib2.type.numeric.real.FloatType
 import net.imglib2.util.Intervals
 import net.imglib2.view.Views
+import org.joml.Vector3f
 import kotlin.math.pow
 import kotlin.math.sqrt
 
@@ -21,14 +22,14 @@ class SphericalDatasetGenerator {
             val ij = ImageJ()
 
             // Run the example
-            SphericalDatasetGenerator().run()
+            SphericalDatasetGenerator().run(ij)
 
             // Display the ImageJ window
             ij.ui().showUI()
         }
     }
 
-    fun run() {
+    fun run(ij: ImageJ) {
         // Define dimensions
         val width = 100L
         val height = 100L
@@ -64,13 +65,12 @@ class SphericalDatasetGenerator {
                             (z - centerZ).pow(2)
                 )
 
-                val intensity = if (distance <= radius) {
-                    (1 - distance / radius).coerceIn(0.0, 1.0)
-                } else {
-                    0.0
+                val intensity = when {
+                    distance <= radius -> (radius - distance) / radius
+                    else -> 0.0
                 }
 
-                cursor.get().set(intensity.toFloat())
+                cursor.get().setReal(intensity.toFloat())
             }
         }
 

--- a/src/test/kotlin/VolumeSamplingTest.kt
+++ b/src/test/kotlin/VolumeSamplingTest.kt
@@ -1,0 +1,76 @@
+
+import bdv.util.AxisOrder
+import bvv.core.VolumeViewerOptions
+import graphics.scenery.*
+import graphics.scenery.backends.Renderer
+import graphics.scenery.primitives.Cylinder
+import graphics.scenery.volumes.TransferFunction
+import graphics.scenery.volumes.Volume
+import ij.IJ
+import ij.ImagePlus
+import net.imglib2.img.Img
+import net.imglib2.img.display.imagej.ImageJFunctions
+import net.imglib2.type.numeric.integer.UnsignedShortType
+import org.joml.Vector3f
+import sc.iview.commands.demo.ResourceLoader
+import java.nio.file.Paths
+
+class VolumeSamplingTest: SceneryBase("VolumeSamplingTest") {
+
+    override fun init() {
+        renderer = hub.add(
+            SceneryElement.Renderer,
+            Renderer.createRenderer(hub, applicationName, scene, windowWidth, windowHeight)
+        )
+
+        val cam: Camera = DetachedHeadCamera()
+        with(cam) {
+            spatial {
+                position = Vector3f(0.0f, 0.0f, 5.0f)
+            }
+            perspectiveCamera(50.0f, 512, 512)
+
+            scene.addChild(this)
+        }
+
+        Light.createLightTetrahedron<PointLight>(spread = 4.0f, radius = 15.0f, intensity = 3f)
+            .forEach { scene.addChild(it) }
+
+        val volume = Volume.fromXML(
+            Paths.get(javaClass.getResource("sphere_dataset.xml")?.toURI()!!).toString(),
+            hub,
+            VolumeViewerOptions()
+        )
+        volume.spatial().scale = Vector3f(40.0f)
+        volume.transferFunction = TransferFunction.ramp(0.001f, .9f, 0.3f)
+        volume.goToTimepoint(20)
+        scene.addChild(volume)
+
+
+        val p1 = Icosphere(0.1f, 2)
+        p1.spatial().position = Vector3f(0.2f, -.5f, -1.5f)
+        p1.material().diffuse = Vector3f(0.3f, 0.3f, 1f)
+        scene.addChild(p1)
+
+        val p2 = Icosphere(0.1f, 2)
+        p2.spatial().position = Vector3f(-.3f,0.5f,1.5f)
+        p2.material().diffuse = Vector3f(0.3f, 1f, 0.3f)
+        scene.addChild(p2)
+
+        val connector = Cylinder.betweenPoints(p1.spatial().position, p2.spatial().position)
+        connector.material().diffuse = Vector3f(1.0f, 1.0f, 1.0f)
+        scene.addChild(connector)
+    }
+
+    override fun inputSetup() {
+        setupCameraModeSwitching()
+    }
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            VolumeSamplingTest().main()
+        }
+    }
+
+}

--- a/src/test/kotlin/VolumeSamplingTest.kt
+++ b/src/test/kotlin/VolumeSamplingTest.kt
@@ -1,21 +1,13 @@
 
-import bdv.util.AxisOrder
 import bvv.core.VolumeViewerOptions
 import graphics.scenery.*
 import graphics.scenery.backends.Renderer
 import graphics.scenery.primitives.Cylinder
 import graphics.scenery.utils.MaybeIntersects
 import graphics.scenery.utils.extensions.minus
-import graphics.scenery.utils.extensions.xyzw
 import graphics.scenery.volumes.TransferFunction
 import graphics.scenery.volumes.Volume
-import ij.IJ
-import ij.ImagePlus
-import net.imglib2.img.Img
-import net.imglib2.img.display.imagej.ImageJFunctions
-import net.imglib2.type.numeric.integer.UnsignedShortType
 import org.joml.Vector3f
-import sc.iview.commands.demo.ResourceLoader
 import java.nio.file.Paths
 import java.text.DecimalFormat
 import kotlin.concurrent.thread

--- a/src/test/kotlin/VolumeSamplingTest.kt
+++ b/src/test/kotlin/VolumeSamplingTest.kt
@@ -4,6 +4,9 @@ import bvv.core.VolumeViewerOptions
 import graphics.scenery.*
 import graphics.scenery.backends.Renderer
 import graphics.scenery.primitives.Cylinder
+import graphics.scenery.utils.MaybeIntersects
+import graphics.scenery.utils.extensions.minus
+import graphics.scenery.utils.extensions.xyzw
 import graphics.scenery.volumes.TransferFunction
 import graphics.scenery.volumes.Volume
 import ij.IJ
@@ -14,8 +17,12 @@ import net.imglib2.type.numeric.integer.UnsignedShortType
 import org.joml.Vector3f
 import sc.iview.commands.demo.ResourceLoader
 import java.nio.file.Paths
+import java.text.DecimalFormat
+import kotlin.concurrent.thread
 
-class VolumeSamplingTest: SceneryBase("VolumeSamplingTest") {
+class VolumeSamplingTest : SceneryBase("VolumeSamplingTest") {
+
+    lateinit var volume: Volume
 
     override fun init() {
         renderer = hub.add(
@@ -36,30 +43,51 @@ class VolumeSamplingTest: SceneryBase("VolumeSamplingTest") {
         Light.createLightTetrahedron<PointLight>(spread = 4.0f, radius = 15.0f, intensity = 3f)
             .forEach { scene.addChild(it) }
 
-        val volume = Volume.fromXML(
+        volume = Volume.fromXML(
             Paths.get(javaClass.getResource("sphere_dataset.xml")?.toURI()!!).toString(),
             hub,
             VolumeViewerOptions()
         )
-        volume.spatial().scale = Vector3f(40.0f)
+        volume.spatial().scale = Vector3f(50.0f)
         volume.transferFunction = TransferFunction.ramp(0.001f, .9f, 0.3f)
         volume.goToTimepoint(20)
         scene.addChild(volume)
 
-
+        logger.info("sampling the center: ${volume.sample(Vector3f(0.5f, 0.5f, 0.5f))}")
         val p1 = Icosphere(0.1f, 2)
-        p1.spatial().position = Vector3f(0.2f, -.5f, -1.5f)
+        p1.spatial().position = Vector3f(0.2f, -.5f, -5f)
         p1.material().diffuse = Vector3f(0.3f, 0.3f, 1f)
         scene.addChild(p1)
 
         val p2 = Icosphere(0.1f, 2)
-        p2.spatial().position = Vector3f(-.3f,0.5f,1.5f)
+        p2.spatial().position = Vector3f(-.3f, 0.5f, 5f)
         p2.material().diffuse = Vector3f(0.3f, 1f, 0.3f)
         scene.addChild(p2)
 
         val connector = Cylinder.betweenPoints(p1.spatial().position, p2.spatial().position)
         connector.material().diffuse = Vector3f(1.0f, 1.0f, 1.0f)
         scene.addChild(connector)
+
+       thread {
+           while (!scene.initialized) {
+               Thread.sleep(200)
+           }
+
+           val intersection = volume.spatial()
+               .intersectAABB(p1.spatial().position, (p2.spatial().position - p1.spatial().position).normalize())
+           if (intersection is MaybeIntersects.Intersection) {
+
+               val scale = volume.localScale()
+               val localEntry = (intersection.relativeEntry)
+               val localExit = (intersection.relativeExit)
+               val nf = DecimalFormat("0.0000")
+               logger.info("local entry: $localEntry, local exit: $localExit")
+               val (samples, samplePos) = volume.sampleRayGridTraversal(localEntry, localExit) ?: (null to null)
+               logger.info("samples are $samples")
+               logger.info("samplePos are $samplePos")
+           }
+       }
+
     }
 
     override fun inputSetup() {

--- a/src/test/resources/sphere_dataset.xml
+++ b/src/test/resources/sphere_dataset.xml
@@ -9,7 +9,7 @@
       <ViewSetup>
         <id>0</id>
         <name>channel 1</name>
-        <size>100 100 50</size>
+        <size>100 100 100</size>
         <voxelSize>
           <unit>pixel</unit>
           <size>1.0 1.0 1.0</size>
@@ -18,1600 +18,16 @@
           <channel>1</channel>
         </attributes>
       </ViewSetup>
-      <ViewSetup>
-        <id>1</id>
-        <name>channel 2</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>2</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>2</id>
-        <name>channel 3</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>3</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>3</id>
-        <name>channel 4</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>4</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>4</id>
-        <name>channel 5</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>5</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>5</id>
-        <name>channel 6</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>6</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>6</id>
-        <name>channel 7</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>7</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>7</id>
-        <name>channel 8</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>8</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>8</id>
-        <name>channel 9</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>9</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>9</id>
-        <name>channel 10</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>10</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>10</id>
-        <name>channel 11</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>11</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>11</id>
-        <name>channel 12</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>12</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>12</id>
-        <name>channel 13</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>13</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>13</id>
-        <name>channel 14</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>14</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>14</id>
-        <name>channel 15</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>15</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>15</id>
-        <name>channel 16</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>16</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>16</id>
-        <name>channel 17</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>17</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>17</id>
-        <name>channel 18</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>18</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>18</id>
-        <name>channel 19</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>19</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>19</id>
-        <name>channel 20</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>20</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>20</id>
-        <name>channel 21</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>21</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>21</id>
-        <name>channel 22</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>22</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>22</id>
-        <name>channel 23</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>23</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>23</id>
-        <name>channel 24</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>24</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>24</id>
-        <name>channel 25</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>25</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>25</id>
-        <name>channel 26</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>26</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>26</id>
-        <name>channel 27</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>27</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>27</id>
-        <name>channel 28</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>28</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>28</id>
-        <name>channel 29</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>29</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>29</id>
-        <name>channel 30</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>30</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>30</id>
-        <name>channel 31</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>31</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>31</id>
-        <name>channel 32</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>32</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>32</id>
-        <name>channel 33</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>33</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>33</id>
-        <name>channel 34</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>34</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>34</id>
-        <name>channel 35</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>35</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>35</id>
-        <name>channel 36</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>36</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>36</id>
-        <name>channel 37</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>37</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>37</id>
-        <name>channel 38</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>38</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>38</id>
-        <name>channel 39</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>39</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>39</id>
-        <name>channel 40</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>40</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>40</id>
-        <name>channel 41</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>41</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>41</id>
-        <name>channel 42</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>42</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>42</id>
-        <name>channel 43</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>43</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>43</id>
-        <name>channel 44</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>44</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>44</id>
-        <name>channel 45</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>45</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>45</id>
-        <name>channel 46</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>46</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>46</id>
-        <name>channel 47</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>47</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>47</id>
-        <name>channel 48</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>48</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>48</id>
-        <name>channel 49</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>49</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>49</id>
-        <name>channel 50</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>50</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>50</id>
-        <name>channel 51</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>51</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>51</id>
-        <name>channel 52</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>52</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>52</id>
-        <name>channel 53</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>53</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>53</id>
-        <name>channel 54</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>54</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>54</id>
-        <name>channel 55</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>55</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>55</id>
-        <name>channel 56</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>56</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>56</id>
-        <name>channel 57</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>57</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>57</id>
-        <name>channel 58</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>58</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>58</id>
-        <name>channel 59</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>59</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>59</id>
-        <name>channel 60</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>60</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>60</id>
-        <name>channel 61</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>61</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>61</id>
-        <name>channel 62</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>62</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>62</id>
-        <name>channel 63</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>63</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>63</id>
-        <name>channel 64</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>64</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>64</id>
-        <name>channel 65</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>65</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>65</id>
-        <name>channel 66</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>66</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>66</id>
-        <name>channel 67</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>67</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>67</id>
-        <name>channel 68</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>68</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>68</id>
-        <name>channel 69</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>69</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>69</id>
-        <name>channel 70</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>70</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>70</id>
-        <name>channel 71</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>71</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>71</id>
-        <name>channel 72</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>72</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>72</id>
-        <name>channel 73</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>73</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>73</id>
-        <name>channel 74</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>74</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>74</id>
-        <name>channel 75</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>75</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>75</id>
-        <name>channel 76</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>76</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>76</id>
-        <name>channel 77</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>77</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>77</id>
-        <name>channel 78</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>78</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>78</id>
-        <name>channel 79</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>79</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>79</id>
-        <name>channel 80</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>80</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>80</id>
-        <name>channel 81</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>81</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>81</id>
-        <name>channel 82</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>82</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>82</id>
-        <name>channel 83</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>83</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>83</id>
-        <name>channel 84</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>84</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>84</id>
-        <name>channel 85</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>85</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>85</id>
-        <name>channel 86</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>86</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>86</id>
-        <name>channel 87</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>87</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>87</id>
-        <name>channel 88</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>88</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>88</id>
-        <name>channel 89</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>89</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>89</id>
-        <name>channel 90</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>90</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>90</id>
-        <name>channel 91</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>91</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>91</id>
-        <name>channel 92</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>92</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>92</id>
-        <name>channel 93</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>93</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>93</id>
-        <name>channel 94</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>94</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>94</id>
-        <name>channel 95</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>95</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>95</id>
-        <name>channel 96</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>96</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>96</id>
-        <name>channel 97</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>97</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>97</id>
-        <name>channel 98</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>98</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>98</id>
-        <name>channel 99</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>99</channel>
-        </attributes>
-      </ViewSetup>
-      <ViewSetup>
-        <id>99</id>
-        <name>channel 100</name>
-        <size>100 100 50</size>
-        <voxelSize>
-          <unit>pixel</unit>
-          <size>1.0 1.0 1.0</size>
-        </voxelSize>
-        <attributes>
-          <channel>100</channel>
-        </attributes>
-      </ViewSetup>
       <Attributes name="channel">
         <Channel>
           <id>1</id>
           <name>1</name>
         </Channel>
-        <Channel>
-          <id>2</id>
-          <name>2</name>
-        </Channel>
-        <Channel>
-          <id>3</id>
-          <name>3</name>
-        </Channel>
-        <Channel>
-          <id>4</id>
-          <name>4</name>
-        </Channel>
-        <Channel>
-          <id>5</id>
-          <name>5</name>
-        </Channel>
-        <Channel>
-          <id>6</id>
-          <name>6</name>
-        </Channel>
-        <Channel>
-          <id>7</id>
-          <name>7</name>
-        </Channel>
-        <Channel>
-          <id>8</id>
-          <name>8</name>
-        </Channel>
-        <Channel>
-          <id>9</id>
-          <name>9</name>
-        </Channel>
-        <Channel>
-          <id>10</id>
-          <name>10</name>
-        </Channel>
-        <Channel>
-          <id>11</id>
-          <name>11</name>
-        </Channel>
-        <Channel>
-          <id>12</id>
-          <name>12</name>
-        </Channel>
-        <Channel>
-          <id>13</id>
-          <name>13</name>
-        </Channel>
-        <Channel>
-          <id>14</id>
-          <name>14</name>
-        </Channel>
-        <Channel>
-          <id>15</id>
-          <name>15</name>
-        </Channel>
-        <Channel>
-          <id>16</id>
-          <name>16</name>
-        </Channel>
-        <Channel>
-          <id>17</id>
-          <name>17</name>
-        </Channel>
-        <Channel>
-          <id>18</id>
-          <name>18</name>
-        </Channel>
-        <Channel>
-          <id>19</id>
-          <name>19</name>
-        </Channel>
-        <Channel>
-          <id>20</id>
-          <name>20</name>
-        </Channel>
-        <Channel>
-          <id>21</id>
-          <name>21</name>
-        </Channel>
-        <Channel>
-          <id>22</id>
-          <name>22</name>
-        </Channel>
-        <Channel>
-          <id>23</id>
-          <name>23</name>
-        </Channel>
-        <Channel>
-          <id>24</id>
-          <name>24</name>
-        </Channel>
-        <Channel>
-          <id>25</id>
-          <name>25</name>
-        </Channel>
-        <Channel>
-          <id>26</id>
-          <name>26</name>
-        </Channel>
-        <Channel>
-          <id>27</id>
-          <name>27</name>
-        </Channel>
-        <Channel>
-          <id>28</id>
-          <name>28</name>
-        </Channel>
-        <Channel>
-          <id>29</id>
-          <name>29</name>
-        </Channel>
-        <Channel>
-          <id>30</id>
-          <name>30</name>
-        </Channel>
-        <Channel>
-          <id>31</id>
-          <name>31</name>
-        </Channel>
-        <Channel>
-          <id>32</id>
-          <name>32</name>
-        </Channel>
-        <Channel>
-          <id>33</id>
-          <name>33</name>
-        </Channel>
-        <Channel>
-          <id>34</id>
-          <name>34</name>
-        </Channel>
-        <Channel>
-          <id>35</id>
-          <name>35</name>
-        </Channel>
-        <Channel>
-          <id>36</id>
-          <name>36</name>
-        </Channel>
-        <Channel>
-          <id>37</id>
-          <name>37</name>
-        </Channel>
-        <Channel>
-          <id>38</id>
-          <name>38</name>
-        </Channel>
-        <Channel>
-          <id>39</id>
-          <name>39</name>
-        </Channel>
-        <Channel>
-          <id>40</id>
-          <name>40</name>
-        </Channel>
-        <Channel>
-          <id>41</id>
-          <name>41</name>
-        </Channel>
-        <Channel>
-          <id>42</id>
-          <name>42</name>
-        </Channel>
-        <Channel>
-          <id>43</id>
-          <name>43</name>
-        </Channel>
-        <Channel>
-          <id>44</id>
-          <name>44</name>
-        </Channel>
-        <Channel>
-          <id>45</id>
-          <name>45</name>
-        </Channel>
-        <Channel>
-          <id>46</id>
-          <name>46</name>
-        </Channel>
-        <Channel>
-          <id>47</id>
-          <name>47</name>
-        </Channel>
-        <Channel>
-          <id>48</id>
-          <name>48</name>
-        </Channel>
-        <Channel>
-          <id>49</id>
-          <name>49</name>
-        </Channel>
-        <Channel>
-          <id>50</id>
-          <name>50</name>
-        </Channel>
-        <Channel>
-          <id>51</id>
-          <name>51</name>
-        </Channel>
-        <Channel>
-          <id>52</id>
-          <name>52</name>
-        </Channel>
-        <Channel>
-          <id>53</id>
-          <name>53</name>
-        </Channel>
-        <Channel>
-          <id>54</id>
-          <name>54</name>
-        </Channel>
-        <Channel>
-          <id>55</id>
-          <name>55</name>
-        </Channel>
-        <Channel>
-          <id>56</id>
-          <name>56</name>
-        </Channel>
-        <Channel>
-          <id>57</id>
-          <name>57</name>
-        </Channel>
-        <Channel>
-          <id>58</id>
-          <name>58</name>
-        </Channel>
-        <Channel>
-          <id>59</id>
-          <name>59</name>
-        </Channel>
-        <Channel>
-          <id>60</id>
-          <name>60</name>
-        </Channel>
-        <Channel>
-          <id>61</id>
-          <name>61</name>
-        </Channel>
-        <Channel>
-          <id>62</id>
-          <name>62</name>
-        </Channel>
-        <Channel>
-          <id>63</id>
-          <name>63</name>
-        </Channel>
-        <Channel>
-          <id>64</id>
-          <name>64</name>
-        </Channel>
-        <Channel>
-          <id>65</id>
-          <name>65</name>
-        </Channel>
-        <Channel>
-          <id>66</id>
-          <name>66</name>
-        </Channel>
-        <Channel>
-          <id>67</id>
-          <name>67</name>
-        </Channel>
-        <Channel>
-          <id>68</id>
-          <name>68</name>
-        </Channel>
-        <Channel>
-          <id>69</id>
-          <name>69</name>
-        </Channel>
-        <Channel>
-          <id>70</id>
-          <name>70</name>
-        </Channel>
-        <Channel>
-          <id>71</id>
-          <name>71</name>
-        </Channel>
-        <Channel>
-          <id>72</id>
-          <name>72</name>
-        </Channel>
-        <Channel>
-          <id>73</id>
-          <name>73</name>
-        </Channel>
-        <Channel>
-          <id>74</id>
-          <name>74</name>
-        </Channel>
-        <Channel>
-          <id>75</id>
-          <name>75</name>
-        </Channel>
-        <Channel>
-          <id>76</id>
-          <name>76</name>
-        </Channel>
-        <Channel>
-          <id>77</id>
-          <name>77</name>
-        </Channel>
-        <Channel>
-          <id>78</id>
-          <name>78</name>
-        </Channel>
-        <Channel>
-          <id>79</id>
-          <name>79</name>
-        </Channel>
-        <Channel>
-          <id>80</id>
-          <name>80</name>
-        </Channel>
-        <Channel>
-          <id>81</id>
-          <name>81</name>
-        </Channel>
-        <Channel>
-          <id>82</id>
-          <name>82</name>
-        </Channel>
-        <Channel>
-          <id>83</id>
-          <name>83</name>
-        </Channel>
-        <Channel>
-          <id>84</id>
-          <name>84</name>
-        </Channel>
-        <Channel>
-          <id>85</id>
-          <name>85</name>
-        </Channel>
-        <Channel>
-          <id>86</id>
-          <name>86</name>
-        </Channel>
-        <Channel>
-          <id>87</id>
-          <name>87</name>
-        </Channel>
-        <Channel>
-          <id>88</id>
-          <name>88</name>
-        </Channel>
-        <Channel>
-          <id>89</id>
-          <name>89</name>
-        </Channel>
-        <Channel>
-          <id>90</id>
-          <name>90</name>
-        </Channel>
-        <Channel>
-          <id>91</id>
-          <name>91</name>
-        </Channel>
-        <Channel>
-          <id>92</id>
-          <name>92</name>
-        </Channel>
-        <Channel>
-          <id>93</id>
-          <name>93</name>
-        </Channel>
-        <Channel>
-          <id>94</id>
-          <name>94</name>
-        </Channel>
-        <Channel>
-          <id>95</id>
-          <name>95</name>
-        </Channel>
-        <Channel>
-          <id>96</id>
-          <name>96</name>
-        </Channel>
-        <Channel>
-          <id>97</id>
-          <name>97</name>
-        </Channel>
-        <Channel>
-          <id>98</id>
-          <name>98</name>
-        </Channel>
-        <Channel>
-          <id>99</id>
-          <name>99</name>
-        </Channel>
-        <Channel>
-          <id>100</id>
-          <name>100</name>
-        </Channel>
       </Attributes>
     </ViewSetups>
     <Timepoints type="range">
       <first>0</first>
-      <last>0</last>
+      <last>49</last>
     </Timepoints>
   </SequenceDescription>
   <ViewRegistrations>
@@ -1620,497 +36,247 @@
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="1">
+    <ViewRegistration timepoint="1" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="2">
+    <ViewRegistration timepoint="2" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="3">
+    <ViewRegistration timepoint="3" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="4">
+    <ViewRegistration timepoint="4" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="5">
+    <ViewRegistration timepoint="5" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="6">
+    <ViewRegistration timepoint="6" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="7">
+    <ViewRegistration timepoint="7" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="8">
+    <ViewRegistration timepoint="8" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="9">
+    <ViewRegistration timepoint="9" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="10">
+    <ViewRegistration timepoint="10" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="11">
+    <ViewRegistration timepoint="11" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="12">
+    <ViewRegistration timepoint="12" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="13">
+    <ViewRegistration timepoint="13" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="14">
+    <ViewRegistration timepoint="14" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="15">
+    <ViewRegistration timepoint="15" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="16">
+    <ViewRegistration timepoint="16" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="17">
+    <ViewRegistration timepoint="17" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="18">
+    <ViewRegistration timepoint="18" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="19">
+    <ViewRegistration timepoint="19" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="20">
+    <ViewRegistration timepoint="20" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="21">
+    <ViewRegistration timepoint="21" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="22">
+    <ViewRegistration timepoint="22" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="23">
+    <ViewRegistration timepoint="23" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="24">
+    <ViewRegistration timepoint="24" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="25">
+    <ViewRegistration timepoint="25" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="26">
+    <ViewRegistration timepoint="26" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="27">
+    <ViewRegistration timepoint="27" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="28">
+    <ViewRegistration timepoint="28" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="29">
+    <ViewRegistration timepoint="29" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="30">
+    <ViewRegistration timepoint="30" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="31">
+    <ViewRegistration timepoint="31" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="32">
+    <ViewRegistration timepoint="32" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="33">
+    <ViewRegistration timepoint="33" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="34">
+    <ViewRegistration timepoint="34" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="35">
+    <ViewRegistration timepoint="35" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="36">
+    <ViewRegistration timepoint="36" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="37">
+    <ViewRegistration timepoint="37" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="38">
+    <ViewRegistration timepoint="38" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="39">
+    <ViewRegistration timepoint="39" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="40">
+    <ViewRegistration timepoint="40" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="41">
+    <ViewRegistration timepoint="41" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="42">
+    <ViewRegistration timepoint="42" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="43">
+    <ViewRegistration timepoint="43" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="44">
+    <ViewRegistration timepoint="44" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="45">
+    <ViewRegistration timepoint="45" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="46">
+    <ViewRegistration timepoint="46" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="47">
+    <ViewRegistration timepoint="47" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="48">
+    <ViewRegistration timepoint="48" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>
     </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="49">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="50">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="51">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="52">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="53">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="54">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="55">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="56">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="57">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="58">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="59">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="60">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="61">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="62">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="63">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="64">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="65">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="66">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="67">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="68">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="69">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="70">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="71">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="72">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="73">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="74">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="75">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="76">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="77">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="78">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="79">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="80">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="81">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="82">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="83">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="84">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="85">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="86">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="87">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="88">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="89">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="90">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="91">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="92">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="93">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="94">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="95">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="96">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="97">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="98">
-      <ViewTransform type="affine">
-        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
-      </ViewTransform>
-    </ViewRegistration>
-    <ViewRegistration timepoint="0" setup="99">
+    <ViewRegistration timepoint="49" setup="0">
       <ViewTransform type="affine">
         <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
       </ViewTransform>

--- a/src/test/resources/sphere_dataset.xml
+++ b/src/test/resources/sphere_dataset.xml
@@ -1,0 +1,2119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpimData version="0.2">
+  <BasePath type="relative">.</BasePath>
+  <SequenceDescription>
+    <ImageLoader format="bdv.hdf5">
+      <hdf5 type="relative">sphere_dataset.h5</hdf5>
+    </ImageLoader>
+    <ViewSetups>
+      <ViewSetup>
+        <id>0</id>
+        <name>channel 1</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>1</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>1</id>
+        <name>channel 2</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>2</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>2</id>
+        <name>channel 3</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>3</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>3</id>
+        <name>channel 4</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>4</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>4</id>
+        <name>channel 5</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>5</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>5</id>
+        <name>channel 6</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>6</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>6</id>
+        <name>channel 7</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>7</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>7</id>
+        <name>channel 8</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>8</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>8</id>
+        <name>channel 9</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>9</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>9</id>
+        <name>channel 10</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>10</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>10</id>
+        <name>channel 11</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>11</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>11</id>
+        <name>channel 12</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>12</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>12</id>
+        <name>channel 13</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>13</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>13</id>
+        <name>channel 14</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>14</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>14</id>
+        <name>channel 15</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>15</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>15</id>
+        <name>channel 16</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>16</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>16</id>
+        <name>channel 17</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>17</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>17</id>
+        <name>channel 18</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>18</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>18</id>
+        <name>channel 19</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>19</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>19</id>
+        <name>channel 20</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>20</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>20</id>
+        <name>channel 21</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>21</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>21</id>
+        <name>channel 22</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>22</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>22</id>
+        <name>channel 23</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>23</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>23</id>
+        <name>channel 24</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>24</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>24</id>
+        <name>channel 25</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>25</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>25</id>
+        <name>channel 26</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>26</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>26</id>
+        <name>channel 27</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>27</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>27</id>
+        <name>channel 28</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>28</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>28</id>
+        <name>channel 29</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>29</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>29</id>
+        <name>channel 30</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>30</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>30</id>
+        <name>channel 31</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>31</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>31</id>
+        <name>channel 32</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>32</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>32</id>
+        <name>channel 33</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>33</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>33</id>
+        <name>channel 34</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>34</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>34</id>
+        <name>channel 35</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>35</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>35</id>
+        <name>channel 36</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>36</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>36</id>
+        <name>channel 37</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>37</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>37</id>
+        <name>channel 38</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>38</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>38</id>
+        <name>channel 39</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>39</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>39</id>
+        <name>channel 40</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>40</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>40</id>
+        <name>channel 41</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>41</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>41</id>
+        <name>channel 42</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>42</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>42</id>
+        <name>channel 43</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>43</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>43</id>
+        <name>channel 44</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>44</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>44</id>
+        <name>channel 45</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>45</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>45</id>
+        <name>channel 46</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>46</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>46</id>
+        <name>channel 47</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>47</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>47</id>
+        <name>channel 48</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>48</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>48</id>
+        <name>channel 49</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>49</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>49</id>
+        <name>channel 50</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>50</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>50</id>
+        <name>channel 51</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>51</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>51</id>
+        <name>channel 52</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>52</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>52</id>
+        <name>channel 53</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>53</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>53</id>
+        <name>channel 54</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>54</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>54</id>
+        <name>channel 55</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>55</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>55</id>
+        <name>channel 56</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>56</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>56</id>
+        <name>channel 57</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>57</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>57</id>
+        <name>channel 58</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>58</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>58</id>
+        <name>channel 59</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>59</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>59</id>
+        <name>channel 60</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>60</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>60</id>
+        <name>channel 61</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>61</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>61</id>
+        <name>channel 62</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>62</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>62</id>
+        <name>channel 63</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>63</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>63</id>
+        <name>channel 64</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>64</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>64</id>
+        <name>channel 65</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>65</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>65</id>
+        <name>channel 66</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>66</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>66</id>
+        <name>channel 67</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>67</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>67</id>
+        <name>channel 68</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>68</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>68</id>
+        <name>channel 69</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>69</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>69</id>
+        <name>channel 70</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>70</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>70</id>
+        <name>channel 71</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>71</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>71</id>
+        <name>channel 72</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>72</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>72</id>
+        <name>channel 73</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>73</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>73</id>
+        <name>channel 74</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>74</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>74</id>
+        <name>channel 75</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>75</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>75</id>
+        <name>channel 76</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>76</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>76</id>
+        <name>channel 77</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>77</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>77</id>
+        <name>channel 78</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>78</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>78</id>
+        <name>channel 79</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>79</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>79</id>
+        <name>channel 80</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>80</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>80</id>
+        <name>channel 81</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>81</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>81</id>
+        <name>channel 82</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>82</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>82</id>
+        <name>channel 83</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>83</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>83</id>
+        <name>channel 84</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>84</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>84</id>
+        <name>channel 85</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>85</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>85</id>
+        <name>channel 86</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>86</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>86</id>
+        <name>channel 87</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>87</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>87</id>
+        <name>channel 88</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>88</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>88</id>
+        <name>channel 89</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>89</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>89</id>
+        <name>channel 90</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>90</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>90</id>
+        <name>channel 91</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>91</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>91</id>
+        <name>channel 92</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>92</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>92</id>
+        <name>channel 93</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>93</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>93</id>
+        <name>channel 94</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>94</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>94</id>
+        <name>channel 95</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>95</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>95</id>
+        <name>channel 96</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>96</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>96</id>
+        <name>channel 97</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>97</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>97</id>
+        <name>channel 98</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>98</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>98</id>
+        <name>channel 99</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>99</channel>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>99</id>
+        <name>channel 100</name>
+        <size>100 100 50</size>
+        <voxelSize>
+          <unit>pixel</unit>
+          <size>1.0 1.0 1.0</size>
+        </voxelSize>
+        <attributes>
+          <channel>100</channel>
+        </attributes>
+      </ViewSetup>
+      <Attributes name="channel">
+        <Channel>
+          <id>1</id>
+          <name>1</name>
+        </Channel>
+        <Channel>
+          <id>2</id>
+          <name>2</name>
+        </Channel>
+        <Channel>
+          <id>3</id>
+          <name>3</name>
+        </Channel>
+        <Channel>
+          <id>4</id>
+          <name>4</name>
+        </Channel>
+        <Channel>
+          <id>5</id>
+          <name>5</name>
+        </Channel>
+        <Channel>
+          <id>6</id>
+          <name>6</name>
+        </Channel>
+        <Channel>
+          <id>7</id>
+          <name>7</name>
+        </Channel>
+        <Channel>
+          <id>8</id>
+          <name>8</name>
+        </Channel>
+        <Channel>
+          <id>9</id>
+          <name>9</name>
+        </Channel>
+        <Channel>
+          <id>10</id>
+          <name>10</name>
+        </Channel>
+        <Channel>
+          <id>11</id>
+          <name>11</name>
+        </Channel>
+        <Channel>
+          <id>12</id>
+          <name>12</name>
+        </Channel>
+        <Channel>
+          <id>13</id>
+          <name>13</name>
+        </Channel>
+        <Channel>
+          <id>14</id>
+          <name>14</name>
+        </Channel>
+        <Channel>
+          <id>15</id>
+          <name>15</name>
+        </Channel>
+        <Channel>
+          <id>16</id>
+          <name>16</name>
+        </Channel>
+        <Channel>
+          <id>17</id>
+          <name>17</name>
+        </Channel>
+        <Channel>
+          <id>18</id>
+          <name>18</name>
+        </Channel>
+        <Channel>
+          <id>19</id>
+          <name>19</name>
+        </Channel>
+        <Channel>
+          <id>20</id>
+          <name>20</name>
+        </Channel>
+        <Channel>
+          <id>21</id>
+          <name>21</name>
+        </Channel>
+        <Channel>
+          <id>22</id>
+          <name>22</name>
+        </Channel>
+        <Channel>
+          <id>23</id>
+          <name>23</name>
+        </Channel>
+        <Channel>
+          <id>24</id>
+          <name>24</name>
+        </Channel>
+        <Channel>
+          <id>25</id>
+          <name>25</name>
+        </Channel>
+        <Channel>
+          <id>26</id>
+          <name>26</name>
+        </Channel>
+        <Channel>
+          <id>27</id>
+          <name>27</name>
+        </Channel>
+        <Channel>
+          <id>28</id>
+          <name>28</name>
+        </Channel>
+        <Channel>
+          <id>29</id>
+          <name>29</name>
+        </Channel>
+        <Channel>
+          <id>30</id>
+          <name>30</name>
+        </Channel>
+        <Channel>
+          <id>31</id>
+          <name>31</name>
+        </Channel>
+        <Channel>
+          <id>32</id>
+          <name>32</name>
+        </Channel>
+        <Channel>
+          <id>33</id>
+          <name>33</name>
+        </Channel>
+        <Channel>
+          <id>34</id>
+          <name>34</name>
+        </Channel>
+        <Channel>
+          <id>35</id>
+          <name>35</name>
+        </Channel>
+        <Channel>
+          <id>36</id>
+          <name>36</name>
+        </Channel>
+        <Channel>
+          <id>37</id>
+          <name>37</name>
+        </Channel>
+        <Channel>
+          <id>38</id>
+          <name>38</name>
+        </Channel>
+        <Channel>
+          <id>39</id>
+          <name>39</name>
+        </Channel>
+        <Channel>
+          <id>40</id>
+          <name>40</name>
+        </Channel>
+        <Channel>
+          <id>41</id>
+          <name>41</name>
+        </Channel>
+        <Channel>
+          <id>42</id>
+          <name>42</name>
+        </Channel>
+        <Channel>
+          <id>43</id>
+          <name>43</name>
+        </Channel>
+        <Channel>
+          <id>44</id>
+          <name>44</name>
+        </Channel>
+        <Channel>
+          <id>45</id>
+          <name>45</name>
+        </Channel>
+        <Channel>
+          <id>46</id>
+          <name>46</name>
+        </Channel>
+        <Channel>
+          <id>47</id>
+          <name>47</name>
+        </Channel>
+        <Channel>
+          <id>48</id>
+          <name>48</name>
+        </Channel>
+        <Channel>
+          <id>49</id>
+          <name>49</name>
+        </Channel>
+        <Channel>
+          <id>50</id>
+          <name>50</name>
+        </Channel>
+        <Channel>
+          <id>51</id>
+          <name>51</name>
+        </Channel>
+        <Channel>
+          <id>52</id>
+          <name>52</name>
+        </Channel>
+        <Channel>
+          <id>53</id>
+          <name>53</name>
+        </Channel>
+        <Channel>
+          <id>54</id>
+          <name>54</name>
+        </Channel>
+        <Channel>
+          <id>55</id>
+          <name>55</name>
+        </Channel>
+        <Channel>
+          <id>56</id>
+          <name>56</name>
+        </Channel>
+        <Channel>
+          <id>57</id>
+          <name>57</name>
+        </Channel>
+        <Channel>
+          <id>58</id>
+          <name>58</name>
+        </Channel>
+        <Channel>
+          <id>59</id>
+          <name>59</name>
+        </Channel>
+        <Channel>
+          <id>60</id>
+          <name>60</name>
+        </Channel>
+        <Channel>
+          <id>61</id>
+          <name>61</name>
+        </Channel>
+        <Channel>
+          <id>62</id>
+          <name>62</name>
+        </Channel>
+        <Channel>
+          <id>63</id>
+          <name>63</name>
+        </Channel>
+        <Channel>
+          <id>64</id>
+          <name>64</name>
+        </Channel>
+        <Channel>
+          <id>65</id>
+          <name>65</name>
+        </Channel>
+        <Channel>
+          <id>66</id>
+          <name>66</name>
+        </Channel>
+        <Channel>
+          <id>67</id>
+          <name>67</name>
+        </Channel>
+        <Channel>
+          <id>68</id>
+          <name>68</name>
+        </Channel>
+        <Channel>
+          <id>69</id>
+          <name>69</name>
+        </Channel>
+        <Channel>
+          <id>70</id>
+          <name>70</name>
+        </Channel>
+        <Channel>
+          <id>71</id>
+          <name>71</name>
+        </Channel>
+        <Channel>
+          <id>72</id>
+          <name>72</name>
+        </Channel>
+        <Channel>
+          <id>73</id>
+          <name>73</name>
+        </Channel>
+        <Channel>
+          <id>74</id>
+          <name>74</name>
+        </Channel>
+        <Channel>
+          <id>75</id>
+          <name>75</name>
+        </Channel>
+        <Channel>
+          <id>76</id>
+          <name>76</name>
+        </Channel>
+        <Channel>
+          <id>77</id>
+          <name>77</name>
+        </Channel>
+        <Channel>
+          <id>78</id>
+          <name>78</name>
+        </Channel>
+        <Channel>
+          <id>79</id>
+          <name>79</name>
+        </Channel>
+        <Channel>
+          <id>80</id>
+          <name>80</name>
+        </Channel>
+        <Channel>
+          <id>81</id>
+          <name>81</name>
+        </Channel>
+        <Channel>
+          <id>82</id>
+          <name>82</name>
+        </Channel>
+        <Channel>
+          <id>83</id>
+          <name>83</name>
+        </Channel>
+        <Channel>
+          <id>84</id>
+          <name>84</name>
+        </Channel>
+        <Channel>
+          <id>85</id>
+          <name>85</name>
+        </Channel>
+        <Channel>
+          <id>86</id>
+          <name>86</name>
+        </Channel>
+        <Channel>
+          <id>87</id>
+          <name>87</name>
+        </Channel>
+        <Channel>
+          <id>88</id>
+          <name>88</name>
+        </Channel>
+        <Channel>
+          <id>89</id>
+          <name>89</name>
+        </Channel>
+        <Channel>
+          <id>90</id>
+          <name>90</name>
+        </Channel>
+        <Channel>
+          <id>91</id>
+          <name>91</name>
+        </Channel>
+        <Channel>
+          <id>92</id>
+          <name>92</name>
+        </Channel>
+        <Channel>
+          <id>93</id>
+          <name>93</name>
+        </Channel>
+        <Channel>
+          <id>94</id>
+          <name>94</name>
+        </Channel>
+        <Channel>
+          <id>95</id>
+          <name>95</name>
+        </Channel>
+        <Channel>
+          <id>96</id>
+          <name>96</name>
+        </Channel>
+        <Channel>
+          <id>97</id>
+          <name>97</name>
+        </Channel>
+        <Channel>
+          <id>98</id>
+          <name>98</name>
+        </Channel>
+        <Channel>
+          <id>99</id>
+          <name>99</name>
+        </Channel>
+        <Channel>
+          <id>100</id>
+          <name>100</name>
+        </Channel>
+      </Attributes>
+    </ViewSetups>
+    <Timepoints type="range">
+      <first>0</first>
+      <last>0</last>
+    </Timepoints>
+  </SequenceDescription>
+  <ViewRegistrations>
+    <ViewRegistration timepoint="0" setup="0">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="1">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="2">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="3">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="4">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="5">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="6">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="7">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="8">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="9">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="10">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="11">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="12">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="13">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="14">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="15">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="16">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="17">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="18">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="19">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="20">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="21">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="22">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="23">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="24">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="25">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="26">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="27">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="28">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="29">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="30">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="31">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="32">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="33">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="34">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="35">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="36">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="37">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="38">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="39">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="40">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="41">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="42">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="43">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="44">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="45">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="46">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="47">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="48">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="49">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="50">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="51">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="52">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="53">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="54">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="55">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="56">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="57">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="58">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="59">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="60">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="61">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="62">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="63">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="64">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="65">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="66">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="67">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="68">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="69">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="70">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="71">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="72">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="73">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="74">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="75">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="76">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="77">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="78">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="79">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="80">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="81">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="82">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="83">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="84">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="85">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="86">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="87">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="88">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="89">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="90">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="91">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="92">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="93">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="94">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="95">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="96">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="97">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="98">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="99">
+      <ViewTransform type="affine">
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+  </ViewRegistrations>
+</SpimData>


### PR DESCRIPTION
This PR adds the eyetracking functionality of the [corresponding sciview branch](https://github.com/scenerygraphics/sciview/tree/eyetracking-utilization) to the bridge. Tracks from the eyetracking are converted mastodon edges and instanced segments. A mipmap level spinner model was added.